### PR TITLE
ZOB-98 Change how info banner content is displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This is a changelog for **ZachranObed** application.
 ### Added
 
 ### Fixed
+- **ZOB-98** Change how info banner content is displayed.
 
 ### Changed
 - **ZOB-96** Move FAB to overview screen, add button on empty page.

--- a/lib/ui/screens/overview_screen.dart
+++ b/lib/ui/screens/overview_screen.dart
@@ -82,16 +82,23 @@ class OverviewScreen extends StatelessWidget {
   Widget _buildDeliveryConfirmedBanner(BuildContext context, Canteen user) {
     return SliverToBoxAdapter(
       child: InfoBanner(
-        infoText: context.l10n!.courierWillCome,
-        infoValue: Text(
-          '${user.pickUpFrom} a ${user.pickUpWithin}',
-          style: const TextStyle(
-            fontWeight: FontWeight.bold,
-            fontSize: FontSize.s,
-            color: ZOColors.onPrimaryLight,
+        backgroundColor: ZOColors.successLight,
+        message: Text.rich(
+          textAlign: TextAlign.center,
+          TextSpan(
+            text: '${context.l10n!.courierWillCome} ',
+            style: const TextStyle(
+              color: ZOColors.onPrimaryLight,
+              fontSize: FontSize.s,
+            ),
+            children: <InlineSpan>[
+              TextSpan(
+                text: '${user.pickUpFrom} a ${user.pickUpWithin}',
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+            ],
           ),
         ),
-        backgroundColor: ZOColors.successLight,
       ),
     );
   }
@@ -99,8 +106,8 @@ class OverviewScreen extends StatelessWidget {
   Widget _buildDonationCountdownBanner(BuildContext context) {
     return SliverToBoxAdapter(
       child: InfoBanner(
-        infoText: context.l10n!.youCanDonate,
-        infoValue: const DonationCountdownTimer(),
+        backgroundColor: ZOColors.successLight,
+        message: const DonationCountdownTimer(),
         button: ZOButton(
           text: context.l10n!.callACourier,
           fullWidth: false,
@@ -111,7 +118,6 @@ class OverviewScreen extends StatelessWidget {
                 .updateDeliveryState(DeliveryState.accepted);
           },
         ),
-        backgroundColor: ZOColors.successLight,
       ),
     );
   }

--- a/lib/ui/widgets/donation_countdown_timer.dart
+++ b/lib/ui/widgets/donation_countdown_timer.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:zachranobed/common/constants.dart';
 import 'package:zachranobed/common/helper_service.dart';
 import 'package:zachranobed/common/lifecycle/lifecycle_watcher.dart';
+import 'package:zachranobed/extensions/build_context_extensions.dart';
 import 'package:zachranobed/models/canteen.dart';
 import 'package:zachranobed/models/delivery.dart';
 import 'package:zachranobed/notifiers/delivery_notifier.dart';
@@ -96,12 +97,20 @@ class _DonationCountdownTimerState extends State<DonationCountdownTimer>
 
   @override
   Widget build(BuildContext context) {
-    return Text(
-      _value,
-      style: const TextStyle(
-        color: ZOColors.onPrimaryLight,
-        fontSize: FontSize.s,
-        fontWeight: FontWeight.bold,
+    return Text.rich(
+      textAlign: TextAlign.center,
+      TextSpan(
+        text: '${context.l10n!.youCanDonate} ',
+        style: const TextStyle(
+          color: ZOColors.onPrimaryLight,
+          fontSize: FontSize.s,
+        ),
+        children: <InlineSpan>[
+          TextSpan(
+            text: _value,
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
+        ],
       ),
     );
   }

--- a/lib/ui/widgets/info_banner.dart
+++ b/lib/ui/widgets/info_banner.dart
@@ -3,15 +3,13 @@ import 'package:zachranobed/common/constants.dart';
 import 'package:zachranobed/ui/widgets/button.dart';
 
 class InfoBanner extends StatelessWidget {
-  final String infoText;
-  final Widget infoValue;
+  final Widget message;
   final Color backgroundColor;
   final ZOButton? button;
 
   const InfoBanner({
     super.key,
-    required this.infoText,
-    required this.infoValue,
+    required this.message,
     required this.backgroundColor,
     this.button,
   });
@@ -25,21 +23,7 @@ class InfoBanner extends StatelessWidget {
         padding: const EdgeInsets.all(WidgetStyle.padding),
         child: Column(
           children: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Flexible(
-                  child: Text(
-                    '$infoText ',
-                    style: const TextStyle(
-                      color: ZOColors.onPrimaryLight,
-                      fontSize: FontSize.s,
-                    ),
-                  ),
-                ),
-                infoValue,
-              ],
-            ),
+            message,
             if (button != null)
               Column(
                 children: [


### PR DESCRIPTION
Jira: https://etnetera.atlassian.net/browse/ZOB-98

* I have refactored Row with 2 Text widgets to single `Text.rich` widget.

<p float="left">
  <img src="https://github.com/zachran-jidlo/zachranobed/assets/80771513/f6fc8b6d-509e-45fe-84fa-8ca7187b9a81" width="300" />
  <img src="https://github.com/zachran-jidlo/zachranobed/assets/80771513/8b7a8879-5de5-4985-b066-9297b9286a20" width="300" /> 
</p>


<p float="left">
  <img src="https://github.com/zachran-jidlo/zachranobed/assets/80771513/2628c3a3-b0de-4dfc-84eb-5184ab6d3915" width="300" /> 
  <img src="https://github.com/zachran-jidlo/zachranobed/assets/80771513/40f54c4e-3c8a-4271-af67-34169a0cdab6" width="300" />
</p>
