### PR TITLE
ZOB-99 Refactor statistics table to support smaller screen sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This is a changelog for **ZachranObed** application.
 
 ### Fixed
 - **ZOB-98** Change how info banner content is displayed.
+- **ZOB-99** Refactor statistics table to support smaller screen sizes.
 - **ZOB-123** Change observation of delivery for displaying the banner for courier arrival.
 - **ZOB-158** Hide list header on overview screen when list is empty.
 

--- a/lib/features/foodboxes/presentation/widget/box_data_table.dart
+++ b/lib/features/foodboxes/presentation/widget/box_data_table.dart
@@ -20,57 +20,85 @@ class BoxDataTable extends StatelessWidget {
       builder: (context, snapshot) {
         if (snapshot.hasData) {
           final boxes = snapshot.data!;
-
-          return Container(
-            decoration: BoxDecoration(
-              border: Border.all(
-                width: 1,
-                color: ZOColors.borderColor,
-              ),
-              borderRadius: const BorderRadius.all(Radius.circular(10)),
-            ),
-            child: DataTable(
-              columnSpacing: 10.0,
-              headingRowHeight: 35.0,
-              dataRowMinHeight: 10.0,
-              dataRowMaxHeight: 35.0,
-              columns: [
-                DataColumn(
-                    label: Text(
-                  context.l10n!.box,
-                  style: const TextStyle(fontWeight: FontWeight.bold),
-                )),
-                DataColumn(
-                    label: Text(
-                  context.l10n!.total,
-                  style: const TextStyle(fontWeight: FontWeight.bold),
-                )),
-                DataColumn(
-                    label: Text(
-                  context.l10n!.charity,
-                  style: const TextStyle(fontWeight: FontWeight.bold),
-                )),
-                DataColumn(
-                    label: Text(
-                  context.l10n!.canteen,
-                  style: const TextStyle(fontWeight: FontWeight.bold),
-                )),
-              ],
-              rows: boxes.map((box) {
-                return DataRow(cells: [
-                  DataCell(Text(box.type.name)),
-                  DataCell(Text(box.totalQuantity.toString())),
-                  DataCell(Text(box.quantityAtCharity.toString())),
-                  DataCell(Text(box.quantityAtCanteen.toString())),
-                ]);
-              }).toList(),
-            ),
-          );
+          return _table(context, boxes);
         } else if (snapshot.hasError) {
           return Center(child: Text('${snapshot.error}'));
         }
         return const Center(child: CircularProgressIndicator());
       },
+    );
+  }
+
+  /// Creates a table widget containing statistics of food boxes.
+  ///
+  /// The [FittedBox] ensures the table is scaled down if it exceeds the width
+  /// constraint on smaller screen sizes. [LayoutBuilder] with
+  /// [ConstrainedBox] are used to propagate all available width as a minimum
+  /// width for the table content, so that on larger screen sizes the first
+  /// column could occupy all remaining width.
+  Widget _table(BuildContext context, Iterable<FoodBoxStatistics> boxes) {
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(width: 1, color: ZOColors.borderColor),
+        borderRadius: const BorderRadius.all(Radius.circular(8)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            return FittedBox(
+              fit: BoxFit.scaleDown,
+              child: ConstrainedBox(
+                constraints: BoxConstraints(minWidth: constraints.maxWidth),
+                child: _tableContent(context, boxes),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _tableContent(
+    BuildContext context,
+    Iterable<FoodBoxStatistics> boxes,
+  ) {
+    return Table(
+      defaultColumnWidth: const IntrinsicColumnWidth(),
+      columnWidths: const <int, TableColumnWidth>{
+        // Makes the first column to occupy all remaining width
+        0: IntrinsicColumnWidth(flex: 1.0),
+      },
+      children: [
+        TableRow(children: [
+          _header(context.l10n!.box),
+          _header(context.l10n!.total),
+          _header(context.l10n!.charity),
+          _header(context.l10n!.canteen),
+        ]),
+        ...boxes.map((box) {
+          return TableRow(children: [
+            _cell(box.type.name),
+            _cell(box.totalQuantity.toString()),
+            _cell(box.quantityAtCharity.toString()),
+            _cell(box.quantityAtCanteen.toString()),
+          ]);
+        }).toList()
+      ],
+    );
+  }
+
+  Widget _header(String text) {
+    return _cell(text, style: const TextStyle(fontWeight: FontWeight.bold));
+  }
+
+  Widget _cell(String text, {TextStyle? style}) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Text(
+        text,
+        style: style,
+      ),
     );
   }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -36,7 +36,7 @@
     "foodCategory": "Druh pokrmu",
     "numberOfServings": "Počet porcí",
     "boxType": "Typ krabičky",
-    "box": "Krabička",
+    "box": "Typ krabičky",
     "consumeBy": "Spotřebujte do",
     "addAnotherFood": "Přidat další",
     "dish": "Pokrm",


### PR DESCRIPTION
Jira: https://etnetera.atlassian.net/browse/ZOB-99

* I have refactored `DataTable` to `Table`, so that we are able to set "weights" on columns.
  * Second, third and fourth columns now occupy the width of the largest cell (header).
  * The first one takes the remaining width.
* On smaller screens the `FittedBox` comes to play and scales down the whole table, so that it fits on the screen.

### Screenshots
* See the "large" screen to the left and "small" screen to the left.
<p float="left">
  <img src="https://github.com/zachran-jidlo/zachranobed/assets/80771513/f990a809-8510-41ba-b5bc-1e80af88b92e" width="300" />
  <img src="https://github.com/zachran-jidlo/zachranobed/assets/80771513/1688f7aa-2ff1-4c53-aa09-51efb777a83f" width="200" /> 
</p>
