### PR TITLE
Add iOS stage and prod workflows

### DIFF
--- a/.github/actions/artifacts-ios/action.yml
+++ b/.github/actions/artifacts-ios/action.yml
@@ -1,0 +1,15 @@
+name: 'Upload iOS Artifacts'
+description: 'Store IPAs in artifacts'
+
+runs:
+  using: 'composite'
+
+  steps:
+    # Uploads build artifacts generated during an iOS build process. This allows easy access
+    # and preservation of these build outputs.
+    - name: Upload iOS artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ios-artifacts
+        path: |
+          **/*.ipa

--- a/.github/actions/build-ipa/action.yml
+++ b/.github/actions/build-ipa/action.yml
@@ -1,0 +1,71 @@
+name: 'Build IPA'
+description: 'Prepares keychain and builds signed IPA'
+
+inputs:
+  certificate_file_base64:
+    description: 'The base64 encoded string of the certificate file (.p12) needed for signing the iOS app'
+    required: true
+  certificate_password:
+    description: 'The password required to decrypt the certificate file (.p12) for signing'
+    required: true
+  provisioning_profile_base64:
+    description: 'The base64 encoded string of the provisioning profile (.mobileprovision) needed for configuring the iOS app'
+    required: true
+  keychain_password:
+    description: 'The password for unlocking the keychain that stores the signing certificates'
+    required: true
+  build_flavor:
+    description: 'The specific configuration or flavor of the build (e.g., dev, stage, prod)'
+    required: true
+  build_export_options:
+    description: 'The property list containing export options for customizing the build process'
+    required: true
+
+runs:
+  using: 'composite'
+
+  steps:
+    # Install the Apple certificate and provisioning profile
+    # See https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
+    - name: Install the Apple certificate and provisioning profile
+      shell: bash
+      env:
+        CERTIFICATE_FILE_BASE64: ${{ inputs.certificate_file_base64 }}
+        CERTIFICATE_PASSWORD: ${{ inputs.certificate_password }}
+        PROVISIONING_PROFILE_BASE64: ${{ inputs.provisioning_profile_base64 }}
+        KEYCHAIN_PASSWORD: ${{ inputs.keychain_password }}
+      run: |
+        # create variables
+        CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+        PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
+        KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+        # import certificate and provisioning profile from secrets
+        echo -n $CERTIFICATE_FILE_BASE64 | base64 --decode --output $CERTIFICATE_PATH
+        echo -n $PROVISIONING_PROFILE_BASE64 | base64 --decode --output $PP_PATH
+        # create temporary keychain
+        security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+        security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+        security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+        # import certificate to keychain
+        security import $CERTIFICATE_PATH -P $CERTIFICATE_PASSWORD -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+        security list-keychain -d user -s $KEYCHAIN_PATH
+        # apply provisioning profile
+        mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+        cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+
+    # Builds a release IPA for the given flavor.
+    - name: Build iOS IPA
+      shell: bash
+      run: |
+        flutter build ipa \
+          --release \
+          --flavor ${{ inputs.build_flavor }} \
+          --export-options-plist ${{ inputs.build_export_options }}
+
+    # Important! Cleanup: remove the certificate and provisioning profile from the runner
+    - name: Clean up keychain and provisioning profile
+      shell: bash
+      if: ${{ always() }}
+      run: |
+        security delete-keychain $RUNNER_TEMP/app-signing.keychain-db
+        rm ~/Library/MobileDevice/Provisioning\ Profiles/build_pp.mobileprovision

--- a/.github/actions/distribute/action.yml
+++ b/.github/actions/distribute/action.yml
@@ -29,16 +29,12 @@ runs:
       shell: bash
       run: npm install -g appcenter-cli
 
-    # Logs in into AppCenter with login token stored in GitHub secrets.
-    - name: Log in to AppCenter
-      shell: bash
-      run: appcenter login --token ${{ inputs.token }}
-
     # Creates a new distribution with release notes created before.
     - name: Upload a file to AppCenter
       shell: bash
       run: |
         appcenter distribute release \
+          --token ${{ inputs.token }} \
           --app ${{ inputs.application }} \
           --file ${{ inputs.path }} \
           --group ${{ inputs.groups }} \

--- a/.github/workflows/build_ios_prod.yml
+++ b/.github/workflows/build_ios_prod.yml
@@ -1,6 +1,9 @@
+# This workflow is designed to automate the process of building a release IPA for the 'prod' flavor
+# of a Flutter application and distributing it to AppCenter.
 name: Build iOS Prod
 
 on:
+  # Workflow is triggered manually through the GitHub Actions interface.
   workflow_dispatch:
 
 jobs:
@@ -8,5 +11,37 @@ jobs:
     runs-on: macos-latest
 
     steps:
+      # Checkouts the repository with entire commit history, which is needed to calculate the
+      # correct build version code in 'Setup environment' step.
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Setups Java, Flutter and correct version code before build.
+      - name: Setup environment
+        uses: ./.github/actions/setup
+
+      # Prepares keychain and builds signed IPA.
+      - name: Build iOS IPA
+        uses: ./.github/actions/build-ipa
+        with:
+          certificate_file_base64: ${{ secrets.IOS_PROD_CERTIFICATE_FILE_BASE64 }}
+          certificate_password: ${{ secrets.IOS_PROD_CERTIFICATE_PASSWORD }}
+          provisioning_profile_base64: ${{ secrets.IOS_PROD_PROVISIONING_PROFILE_BASE64 }}
+          keychain_password: ${{ secrets.IOS_TEMPORARY_KEYCHAIN_PASSWORD }}
+          build_flavor: 'prod'
+          build_export_options: 'ios/ExportOptionsProd.plist'
+
+      # Uploads iOS related artifacts from build to GitHub Actions.
+      - name: Upload artifacts
+        uses: ./.github/actions/artifacts-ios
+
+      # Upload IPA to the AppCenter slot and distribute it with latest release notes.
+      - name: Distribute to AppCenter
+        uses: ./.github/actions/distribute
+        with:
+          token: ${{ secrets.APPCENTER_TOKEN }}
+          path: '"build/ios/ipa/Zachraň Oběd Prod.ipa"'
+          application: ${{ secrets.APPCENTER_IOS_PROD_APP_NAME }}
+          groups: ${{ vars.APPCENTER_GROUPS }}

--- a/.github/workflows/build_ios_stage.yml
+++ b/.github/workflows/build_ios_stage.yml
@@ -1,6 +1,9 @@
+# This workflow is designed to automate the process of building a release IPA for the 'stage' flavor
+# of a Flutter application and distributing it to AppCenter.
 name: Build iOS Stage
 
 on:
+  # Workflow is triggered manually through the GitHub Actions interface.
   workflow_dispatch:
 
 jobs:
@@ -8,5 +11,37 @@ jobs:
     runs-on: macos-latest
 
     steps:
+      # Checkouts the repository with entire commit history, which is needed to calculate the
+      # correct build version code in 'Setup environment' step.
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Setups Java, Flutter and correct version code before build.
+      - name: Setup environment
+        uses: ./.github/actions/setup
+
+      # Prepares keychain and builds signed IPA.
+      - name: Build iOS IPA
+        uses: ./.github/actions/build-ipa
+        with:
+          certificate_file_base64: ${{ secrets.IOS_STAGE_CERTIFICATE_FILE_BASE64 }}
+          certificate_password: ${{ secrets.IOS_STAGE_CERTIFICATE_PASSWORD }}
+          provisioning_profile_base64: ${{ secrets.IOS_STAGE_PROVISIONING_PROFILE_BASE64 }}
+          keychain_password: ${{ secrets.IOS_TEMPORARY_KEYCHAIN_PASSWORD }}
+          build_flavor: 'stage'
+          build_export_options: 'ios/ExportOptionsStage.plist'
+
+      # Uploads iOS related artifacts from build to GitHub Actions.
+      - name: Upload artifacts
+        uses: ./.github/actions/artifacts-ios
+
+      # Upload IPA to the AppCenter slot and distribute it with latest release notes.
+      - name: Distribute to AppCenter
+        uses: ./.github/actions/distribute
+        with:
+          token: ${{ secrets.APPCENTER_TOKEN }}
+          path: '"build/ios/ipa/Zachraň Oběd Stage.ipa"'
+          application: ${{ secrets.APPCENTER_IOS_STAGE_APP_NAME }}
+          groups: ${{ vars.APPCENTER_GROUPS }}

--- a/ios/ExportOptionsProd.plist
+++ b/ios/ExportOptionsProd.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>compileBitcode</key>
+    <true/>
+    <key>method</key>
+    <string>app-store</string>
+    <key>provisioningProfiles</key>
+    <dict>
+        <key>cz.zachranobed.app</key>
+        <string>Zachraň oběd production profile</string>
+    </dict>
+    <key>signingCertificate</key>
+    <string>iOS Distribution</string>
+    <key>signingStyle</key>
+    <string>manual</string>
+    <key>stripSwiftSymbols</key>
+    <true/>
+    <key>teamID</key>
+    <string>5995PDZ75A</string>
+    <key>thinning</key>
+    <string>&lt;none&gt;</string>
+</dict>
+</plist>

--- a/ios/ExportOptionsStage.plist
+++ b/ios/ExportOptionsStage.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>compileBitcode</key>
+    <true/>
+    <key>method</key>
+    <string>enterprise</string>
+    <key>provisioningProfiles</key>
+    <dict>
+        <key>cz.etnetera.mobile.zachranobed.stage</key>
+        <string>Zachran Obed Stage</string>
+    </dict>
+    <key>signingCertificate</key>
+    <string>iOS Distribution</string>
+    <key>signingStyle</key>
+    <string>manual</string>
+    <key>stripSwiftSymbols</key>
+    <true/>
+    <key>teamID</key>
+    <string>6L328QR57Q</string>
+    <key>thinning</key>
+    <string>&lt;none&gt;</string>
+</dict>
+</plist>

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -524,9 +524,11 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = 6L328QR57Q;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 6L328QR57Q;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Zachraň Oběd";
@@ -538,6 +540,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = cz.etnetera.mobile.zachranobed.stage;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Zachran Obed Stage";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -627,7 +630,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = cz.zachranobed.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Production profile";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Zachraň oběd production profile";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -700,9 +703,11 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = 6L328QR57Q;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 6L328QR57Q;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Zachraň Oběd";
@@ -714,6 +719,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = cz.etnetera.mobile.zachranobed.stage;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Zachran Obed Stage";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -865,9 +871,11 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = 6L328QR57Q;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 6L328QR57Q;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Zachraň Oběd";
@@ -879,6 +887,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = cz.etnetera.mobile.zachranobed.stage;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Zachran Obed Stage";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;


### PR DESCRIPTION
# Description

* This PR adds GitHub Actions workflows to build and distribute to AppCenter iOS IPAs for stage and prod flavors.
* Workflows use common local actions, which can be found in `.github/actions` folder.
* All workflows are designed to trigger one-by-one via [Actions](https://github.com/zachran-jidlo/zachranobed/actions) page.
  * Select the needed workflow from the left side, tap on "Run workflow" button to the right and choose a branch to run.
  * It is possible to define other triggers (e.g. merge to release branch, or tag creation), this will be done later in other PRs after discussion with a team.
* Jira: https://etnetera.atlassian.net/browse/ZOB-202
* Note: Stage works fine, but prod still fails, we should discuss it on Thursdays meeting.
* Note2: For Dev flavor the provisioning profile should be created, then we will be able to add a similar workflow. 