### PR TITLE
ZOB-273 Web layout for Login & Forgot Password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is a changelog for **ZachranObed** application.
 ### Fixed
 
 ### Changed
+- **ZOB-273** Adjust web layout for login screen.
 
 ### Removed
 

--- a/lib/common/constants.dart
+++ b/lib/common/constants.dart
@@ -46,6 +46,16 @@ class Constants {
   static const pickupConfirmationTimePersonal = 20;
 }
 
+/// A class that defines layout constants.
+class LayoutStyle {
+  LayoutStyle._();
+
+  /// The breakpoint for screen layouts. If the web screen width is greater
+  /// than this value, the web layout is used. Otherwise, the mobile layout
+  /// is used.
+  static const webBreakpoint = 800;
+}
+
 class WidgetStyle {
   static const inputBorder = OutlineInputBorder(
     borderSide: BorderSide(

--- a/lib/common/constants.dart
+++ b/lib/common/constants.dart
@@ -53,7 +53,7 @@ class LayoutStyle {
   /// The breakpoint for screen layouts. If the web screen width is greater
   /// than this value, the web layout is used. Otherwise, the mobile layout
   /// is used.
-  static const webBreakpoint = 800;
+  static const webBreakpoint = 740;
 }
 
 class WidgetStyle {

--- a/lib/features/foodboxes/presentation/screen/boxes_screen.dart
+++ b/lib/features/foodboxes/presentation/screen/boxes_screen.dart
@@ -105,7 +105,7 @@ class _BoxesScreenState extends State<BoxesScreen> {
                   child: ZOButton(
                     text: context.l10n!.loadMore,
                     icon: Icons.expand_more,
-                    height: 40.0,
+                    minimumSize: ZOButtonSize.medium(),
                     type: ZOButtonType.secondary,
                     onPressed: _addPreviousWeek,
                   ),
@@ -135,7 +135,7 @@ class _BoxesScreenState extends State<BoxesScreen> {
                 children: [
                   ZOButton(
                     text: context.l10n!.orderShippingOfBoxes,
-                    fullWidth: false,
+                    minimumSize: ZOButtonSize.tiny(),
                     onPressed: () {
                       context.router.push(const OrderShippingOfBoxesRoute());
                     },

--- a/lib/features/login/presentation/screen/login_screen.dart
+++ b/lib/features/login/presentation/screen/login_screen.dart
@@ -15,11 +15,15 @@ import 'package:zachranobed/services/auth_service.dart';
 import 'package:zachranobed/ui/widgets/button.dart';
 import 'package:zachranobed/ui/widgets/clickable_text.dart';
 import 'package:zachranobed/ui/widgets/password_text_field.dart';
+import 'package:zachranobed/ui/widgets/screen_content.dart';
 import 'package:zachranobed/ui/widgets/snackbar/temporary_snackbar.dart';
 import 'package:zachranobed/ui/widgets/text_field.dart';
 
 @RoutePage()
 class LoginScreen extends StatefulWidget {
+  /// The fixed width of login form in wide web layout.
+  static const loginFormWidth = 530;
+
   const LoginScreen({super.key});
 
   @override
@@ -28,8 +32,10 @@ class LoginScreen extends StatefulWidget {
 
 class _LoginScreenState extends State<LoginScreen> {
   final _authService = GetIt.I<AuthService>();
-  final _checkIfDevtoolsAreEnabledUseCase = GetIt.I<CheckIfDevtoolsAreEnabledUseCase>();
-  final _checkIfAppTermsShouldBeShownUseCase = GetIt.I<CheckIfAppTermsShouldBeShownUseCase>();
+  final _checkIfDevtoolsAreEnabledUseCase =
+      GetIt.I<CheckIfDevtoolsAreEnabledUseCase>();
+  final _checkIfAppTermsShouldBeShownUseCase =
+      GetIt.I<CheckIfAppTermsShouldBeShownUseCase>();
 
   final _formKey = GlobalKey<FormState>();
 
@@ -47,74 +53,128 @@ class _LoginScreenState extends State<LoginScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       body: SafeArea(
-        child: SingleChildScrollView(
-          child: Column(
-            children: <Widget>[
-              const SizedBox(height: GapSize.xl),
-              SvgPicture.asset(ZOStrings.zoLogoPath, width: 270, height: 46),
-              const SizedBox(height: GapSize.l),
-              GestureDetector(
-                onLongPress: showDebugScreenIfPossible,
-                child: Image.asset(
-                  width: 415,
-                  ZOStrings.foodImagePath,
-                  fit: BoxFit.fitWidth,
-                ),
-              ),
-              const SizedBox(height: GapSize.l),
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: WidgetStyle.padding,
-                ),
-                child: Form(
-                  key: _formKey,
-                  child: Column(
-                    children: <Widget>[
-                      ZOTextField(
-                        label: context.l10n!.emailAddress,
-                        inputType: TextInputType.emailAddress,
-                        disableAutocorrect: true,
-                        controller: _emailController,
-                        onValidation: FieldValidationUtils.getEmailValidator(
-                          context,
-                        ),
-                      ),
-                      const SizedBox(height: GapSize.m),
-                      ZOPasswordTextField(
-                        text: context.l10n!.password,
-                        controller: _passwordController,
-                        onValidation: FieldValidationUtils.getPasswordValidator(
-                          context,
-                        ),
-                      ),
-                      const SizedBox(height: GapSize.l),
-                      ZOButton(
-                        text: context.l10n!.signIn,
-                        icon: MaterialSymbols.login,
-                        onPressed: () async {
-                          if (_formKey.currentState!.validate()) {
-                            await _logIn();
-                          }
-                        },
-                      ),
-                    ],
+        child: ScreenContent(
+          web: (context) {
+            return Row(
+              children: [
+                Expanded(
+                  child: GestureDetector(
+                    onLongPress: showDebugScreenIfPossible,
+                    // TODO (Alex) Use another image with better quality
+                    child: Image.asset(
+                      ZOStrings.foodImagePath,
+                      fit: BoxFit.cover,
+                      height: double.infinity,
+                      opacity: const AlwaysStoppedAnimation(.2),
+                    ),
                   ),
                 ),
-              ),
-              const SizedBox(height: GapSize.m),
-              ZOClickableText(
-                  clickableText: context.l10n!.forgotPassword,
-                  color: ZOColors.onPrimaryLight,
-                  underline: false,
-                  onTap: () {
-                    context.router.push(const ForgotPasswordRoute());
-                  }),
-              const SizedBox(height: 30),
-            ],
-          ),
+                Material(
+                  elevation: 8,
+                  child: SizedBox(
+                    width: LoginScreen.loginFormWidth.toDouble(),
+                    child: Center(
+                      child: _loginScreenContent(
+                        showImageInForm: false,
+                        padding: const EdgeInsets.all(72.0),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
+          mobile: (BuildContext context) {
+            return _loginScreenContent(
+              showImageInForm: true,
+            );
+          },
         ),
       ),
     );
+  }
+
+  Widget _loginScreenContent({
+    required bool showImageInForm,
+    EdgeInsetsGeometry? padding,
+  }) {
+    return SingleChildScrollView(
+      padding: padding,
+      child: Column(
+        children: <Widget>[
+          const SizedBox(height: GapSize.xl),
+          SvgPicture.asset(ZOStrings.zoLogoPath, width: 270, height: 46),
+          _formImageContent(showImageInForm),
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: WidgetStyle.padding,
+            ),
+            child: Form(
+              key: _formKey,
+              child: Column(
+                children: <Widget>[
+                  ZOTextField(
+                    label: context.l10n!.emailAddress,
+                    inputType: TextInputType.emailAddress,
+                    disableAutocorrect: true,
+                    controller: _emailController,
+                    onValidation: FieldValidationUtils.getEmailValidator(
+                      context,
+                    ),
+                  ),
+                  const SizedBox(height: GapSize.m),
+                  ZOPasswordTextField(
+                    text: context.l10n!.password,
+                    controller: _passwordController,
+                    onValidation: FieldValidationUtils.getPasswordValidator(
+                      context,
+                    ),
+                  ),
+                  const SizedBox(height: GapSize.l),
+                  ZOButton(
+                    text: context.l10n!.signIn,
+                    icon: MaterialSymbols.login,
+                    onPressed: () async {
+                      if (_formKey.currentState!.validate()) {
+                        await _logIn();
+                      }
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: GapSize.m),
+          ZOClickableText(
+            clickableText: context.l10n!.forgotPassword,
+            color: ZOColors.onPrimaryLight,
+            underline: false,
+            onTap: () {
+              context.router.push(const ForgotPasswordRoute());
+            },
+          ),
+          const SizedBox(height: 30),
+        ],
+      ),
+    );
+  }
+
+  Widget _formImageContent(bool showImageInForm) {
+    if (showImageInForm) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: GapSize.l),
+        child: GestureDetector(
+          onLongPress: showDebugScreenIfPossible,
+          child: Image.asset(
+            width: double.infinity,
+            ZOStrings.foodImagePath,
+            fit: BoxFit.fitWidth,
+          ),
+        ),
+      );
+    }
+
+    return const SizedBox(height: GapSize.xxl);
   }
 
   void showDebugScreenIfPossible() {

--- a/lib/features/login/presentation/screen/login_screen.dart
+++ b/lib/features/login/presentation/screen/login_screen.dart
@@ -94,6 +94,11 @@ class _LoginScreenState extends State<LoginScreen> {
     );
   }
 
+  /// Builds the content of the login screen.
+  ///
+  /// The [showImageInForm] flag determines whether to show the image
+  /// in the form.
+  /// The [padding] parameter specifies the padding to add around the content.
   Widget _loginScreenContent({
     required bool showImageInForm,
     EdgeInsetsGeometry? padding,
@@ -159,6 +164,10 @@ class _LoginScreenState extends State<LoginScreen> {
     );
   }
 
+  /// Builds the image content for the form.
+  ///
+  /// The [showImageInForm] parameter determines whether to show the image
+  /// in the form. If set to false returns only necessary padding.
   Widget _formImageContent(bool showImageInForm) {
     if (showImageInForm) {
       return Padding(

--- a/lib/features/login/presentation/screen/login_screen.dart
+++ b/lib/features/login/presentation/screen/login_screen.dart
@@ -84,7 +84,7 @@ class _LoginScreenState extends State<LoginScreen> {
               ],
             );
           },
-          mobile: (BuildContext context) {
+          mobile: (context) {
             return _loginScreenContent(
               showImageInForm: true,
             );

--- a/lib/features/offeredfood/presentation/screens/donations_screen.dart
+++ b/lib/features/offeredfood/presentation/screens/donations_screen.dart
@@ -107,7 +107,7 @@ class _DonationsScreenState extends State<DonationsScreen> {
                   child: ZOButton(
                     text: context.l10n!.loadMore,
                     icon: Icons.expand_more,
-                    height: 40.0,
+                    minimumSize: ZOButtonSize.medium(),
                     type: ZOButtonType.secondary,
                     onPressed: _addPreviousWeek,
                   ),

--- a/lib/ui/screens/forgot_password_screen.dart
+++ b/lib/ui/screens/forgot_password_screen.dart
@@ -48,7 +48,7 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
               ),
             );
           },
-          mobile: (BuildContext context) {
+          mobile: (context) {
             return _forgotPasswordScreenContent(
               useWideButton: true,
             );

--- a/lib/ui/screens/forgot_password_screen.dart
+++ b/lib/ui/screens/forgot_password_screen.dart
@@ -8,6 +8,7 @@ import 'package:zachranobed/extensions/build_context_extensions.dart';
 import 'package:zachranobed/routes/app_router.gr.dart';
 import 'package:zachranobed/services/auth_service.dart';
 import 'package:zachranobed/ui/widgets/button.dart';
+import 'package:zachranobed/ui/widgets/screen_content.dart';
 import 'package:zachranobed/ui/widgets/snackbar/temporary_snackbar.dart';
 import 'package:zachranobed/ui/widgets/text_field.dart';
 
@@ -34,6 +35,36 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
 
   @override
   Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: ScreenContent(
+          web: (context) {
+            return Center(
+              child: SizedBox(
+                width: LayoutStyle.webBreakpoint.toDouble(),
+                child: _forgotPasswordScreenContent(
+                  useWideButton: false,
+                ),
+              ),
+            );
+          },
+          mobile: (BuildContext context) {
+            return _forgotPasswordScreenContent(
+              useWideButton: true,
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  /// Builds the content of the forgot password screen.
+  ///
+  /// The [useWideButton] parameter determines whether to stretch confirmation
+  /// button to screen width.
+  Widget _forgotPasswordScreenContent({
+    required bool useWideButton,
+  }) {
     return Scaffold(
       appBar: AppBar(
         title: Text(context.l10n!.passwordReset),
@@ -63,14 +94,18 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
                   ),
                 ),
                 const SizedBox(height: GapSize.xl),
-                ZOButton(
-                  text: context.l10n!.resetPassword,
-                  icon: Icons.email_outlined,
-                  onPressed: () async {
-                    if (_formKey.currentState!.validate()) {
-                      await _resetPassword();
-                    }
-                  },
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: ZOButton(
+                    text: context.l10n!.resetPassword,
+                    icon: Icons.email_outlined,
+                    minimumSize: ZOButtonSize.large(fullWidth: useWideButton),
+                    onPressed: () async {
+                      if (_formKey.currentState!.validate()) {
+                        await _resetPassword();
+                      }
+                    },
+                  ),
                 ),
               ],
             ),

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -83,7 +83,7 @@ class _HomeScreenState extends State<HomeScreen> with LifecycleWatcher {
                         padding: const EdgeInsets.only(top: GapSize.m),
                         child: ZOButton(
                           text: context.l10n!.signOut,
-                          fullWidth: false,
+                          minimumSize: ZOButtonSize.tiny(),
                           onPressed: () async {
                             await authService.signOut();
                             if (context.mounted) {

--- a/lib/ui/screens/offer_food_screen.dart
+++ b/lib/ui/screens/offer_food_screen.dart
@@ -163,7 +163,7 @@ class _OfferFoodScreenState extends State<OfferFoodScreen> {
       text: context.l10n!.addAnotherFood,
       icon: MaterialSymbols.add,
       type: ZOButtonType.secondary,
-      height: 40.0,
+      minimumSize: ZOButtonSize.medium(),
       onPressed: () {
         setState(() {
           _foodSections.add(FoodInfo.withUuid());

--- a/lib/ui/screens/order_shipping_of_boxes_screen.dart
+++ b/lib/ui/screens/order_shipping_of_boxes_screen.dart
@@ -102,7 +102,7 @@ class _OrderShippingOfBoxesScreenState
                         text: context.l10n!.addAnotherBoxType,
                         icon: MaterialSymbols.add,
                         type: ZOButtonType.secondary,
-                        height: 40.0,
+                        minimumSize: ZOButtonSize.medium(),
                         onPressed: () {
                           setState(() {
                             _shippingOfBoxesSections.add(const BoxInfo());

--- a/lib/ui/widgets/app_root.dart
+++ b/lib/ui/widgets/app_root.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:get_it/get_it.dart';
@@ -71,7 +74,9 @@ class _AppRootState extends State<AppRoot> with LifecycleWatcher {
             visualDensity: VisualDensity.adaptivePlatformDensity,
             highlightColor: Colors.transparent,
             splashColor: Colors.transparent,
-            appBarTheme: const AppBarTheme(
+            appBarTheme: AppBarTheme(
+              // Center title only for iOS platform
+              centerTitle: !kIsWeb && Platform.isIOS,
               scrolledUnderElevation: 0,
             ),
           ),

--- a/lib/ui/widgets/button.dart
+++ b/lib/ui/widgets/button.dart
@@ -6,8 +6,7 @@ class ZOButton extends StatelessWidget {
   final VoidCallback onPressed;
   final ZOButtonType type;
   final IconData? icon;
-  final double height;
-  final bool fullWidth;
+  final Size? minimumSize;
 
   const ZOButton({
     super.key,
@@ -15,8 +14,7 @@ class ZOButton extends StatelessWidget {
     required this.onPressed,
     this.type = ZOButtonType.primary,
     this.icon,
-    this.height = 56.0,
-    this.fullWidth = true,
+    this.minimumSize = ZOButtonSize.largeMatchParent,
   });
 
   @override
@@ -24,7 +22,7 @@ class ZOButton extends StatelessWidget {
     final style = ElevatedButton.styleFrom(
       foregroundColor: type.foregroundColor,
       backgroundColor: type.backgroundColor,
-      minimumSize: fullWidth ? Size.fromHeight(height) : null,
+      minimumSize: minimumSize,
       shape: const StadiumBorder(),
       textStyle: const TextStyle(fontSize: FontSize.xs),
     );
@@ -58,4 +56,43 @@ enum ZOButtonType {
 
   final Color backgroundColor;
   final Color foregroundColor;
+}
+
+/// Defines default size of a [ZOButton].
+class ZOButtonSize {
+  /// The height of a large button.
+  static const _heightLarge = 56.0;
+
+  /// The height of a medium button.
+  static const _heightMedium = 40.0;
+
+  static const largeWrapContent = Size(0.0, _heightLarge);
+  static const largeMatchParent = Size(double.infinity, _heightLarge);
+  static const mediumWrapContent = Size(0.0, _heightMedium);
+  static const mediumMatchParent = Size(double.infinity, _heightMedium);
+
+  /// Private constructor to prevent instantiation.
+  ZOButtonSize._();
+
+  /// Returns a size for large (default) button.
+  ///
+  /// The [fullWidth] parameter determines whether the button should match
+  /// parent widget width.
+  static Size? large({bool fullWidth = true}) {
+    return fullWidth ? largeMatchParent : largeWrapContent;
+  }
+
+  /// Returns a size for medium button.
+  ///
+  /// The [fullWidth] parameter determines whether the button should match
+  /// parent widget width.
+  static Size? medium({bool fullWidth = true}) {
+    return fullWidth ? mediumMatchParent : mediumWrapContent;
+  }
+
+  /// Returns a size for tiny button. Tiny button has no minimal size, so
+  /// this method just returns null to use [Button] default behavior.
+  static Size? tiny() {
+    return null;
+  }
 }

--- a/lib/ui/widgets/delivery_info_banner.dart
+++ b/lib/ui/widgets/delivery_info_banner.dart
@@ -84,7 +84,7 @@ class DeliveryInfoBanner extends StatelessWidget {
         message: DonationCountdownTimer(delivery: delivery),
         button: ZOButton(
           text: context.l10n!.wantToDonate,
-          fullWidth: false,
+          minimumSize: ZOButtonSize.tiny(),
           type: ZOButtonType.success,
           onPressed: () {
             context

--- a/lib/ui/widgets/screen_content.dart
+++ b/lib/ui/widgets/screen_content.dart
@@ -8,7 +8,7 @@ import 'package:zachranobed/common/constants.dart';
 /// If the platform is web and the screen width is greater than
 /// [LayoutStyle.webBreakpoint], the [web] child is displayed.
 /// Otherwise, the [mobile] child is displayed.
-class ScreenContent extends StatelessWidget {
+class ScreenContent extends StatefulWidget {
   /// The child to display on the web when the screen width is greater than
   /// [LayoutStyle.webBreakpoint].
   final WidgetBuilder web;
@@ -25,12 +25,31 @@ class ScreenContent extends StatelessWidget {
   });
 
   @override
+  State<ScreenContent> createState() => _ScreenContentState();
+}
+
+/// State for the [ScreenContent] widget.
+///
+/// Manages [_web] and [_mobile] widgets, building them only when needed and
+/// caching them for subsequent use.
+class _ScreenContentState extends State<ScreenContent> {
+  /// The widget to display on the web when the screen width is greater than
+  /// [LayoutStyle.webBreakpoint].
+  Widget? _web;
+
+  /// The widget to display on mobile or when the screen width is less than
+  /// [LayoutStyle.webBreakpoint].
+  Widget? _mobile;
+
+  @override
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (context, constraints) {
       if (kIsWeb && constraints.maxWidth > LayoutStyle.webBreakpoint) {
-        return Builder(builder: web);
+        _web ??= widget.web(context);
+        return _web!;
       }
-      return Builder(builder: mobile);
+      _mobile ??= widget.mobile(context);
+      return _mobile!;
     });
   }
 }

--- a/lib/ui/widgets/screen_content.dart
+++ b/lib/ui/widgets/screen_content.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:zachranobed/common/constants.dart';
+
+/// A widget that displays a different child depending on the platform and
+/// screen size.
+///
+/// If the platform is web and the screen width is greater than
+/// [LayoutStyle.webBreakpoint], the [web] child is displayed.
+/// Otherwise, the [mobile] child is displayed.
+class ScreenContent extends StatelessWidget {
+  /// The child to display on the web when the screen width is greater than
+  /// [LayoutStyle.webBreakpoint].
+  final WidgetBuilder web;
+
+  /// The child to display on mobile or when the screen width is less than
+  /// [LayoutStyle.webBreakpoint].
+  final WidgetBuilder mobile;
+
+  /// Creates a new [ScreenContent] widget.
+  const ScreenContent({
+    super.key,
+    required this.web,
+    required this.mobile,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(builder: (context, constraints) {
+      if (kIsWeb && constraints.maxWidth > LayoutStyle.webBreakpoint) {
+        return Builder(builder: web);
+      }
+      return Builder(builder: mobile);
+    });
+  }
+}

--- a/lib/ui/widgets/screen_content.dart
+++ b/lib/ui/widgets/screen_content.dart
@@ -8,7 +8,7 @@ import 'package:zachranobed/common/constants.dart';
 /// If the platform is web and the screen width is greater than
 /// [LayoutStyle.webBreakpoint], the [web] child is displayed.
 /// Otherwise, the [mobile] child is displayed.
-class ScreenContent extends StatefulWidget {
+class ScreenContent extends StatelessWidget {
   /// The child to display on the web when the screen width is greater than
   /// [LayoutStyle.webBreakpoint].
   final WidgetBuilder web;
@@ -25,31 +25,12 @@ class ScreenContent extends StatefulWidget {
   });
 
   @override
-  State<ScreenContent> createState() => _ScreenContentState();
-}
-
-/// State for the [ScreenContent] widget.
-///
-/// Manages [_web] and [_mobile] widgets, building them only when needed and
-/// caching them for subsequent use.
-class _ScreenContentState extends State<ScreenContent> {
-  /// The widget to display on the web when the screen width is greater than
-  /// [LayoutStyle.webBreakpoint].
-  Widget? _web;
-
-  /// The widget to display on mobile or when the screen width is less than
-  /// [LayoutStyle.webBreakpoint].
-  Widget? _mobile;
-
-  @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(builder: (context, constraints) {
-      if (kIsWeb && constraints.maxWidth > LayoutStyle.webBreakpoint) {
-        _web ??= widget.web(context);
-        return _web!;
-      }
-      _mobile ??= widget.mobile(context);
-      return _mobile!;
-    });
+    final width = MediaQuery.sizeOf(context).width;
+    if (kIsWeb && width > LayoutStyle.webBreakpoint) {
+      return web(context);
+    } else {
+      return mobile(context);
+    }
   }
 }


### PR DESCRIPTION
# Description
* Jira: https://etnetera.atlassian.net/browse/ZOB-273
* This PR introduces two enhancements related to web layout:
  * `ScreenContent` widget enables switching between web-based and mobile-based layouts. The current logic is straightforward: if the screen width exceeds 740 pixels, the web-based layout is displayed, otherwise, the mobile-based layout is used. This means that when the web window shrinks below 740 pixels (into a "mobile-like" size), the layout automatically switches to the mobile-based layout.
  * Refactoring of `ZOButton` size handling. This was needed to support "wrap-content" buttons in web-based layout.
  
* Also this PR adds web-based versions for `LoginScreen` and `ForgotPasswordScreen`.
  * Both screens utilize the `ScreenContent` widget, where `web` and `mobile` lambdas provide web and mobile specific widget trees, while reusing some common UI components. I aimed to keep the shared UI independent of the chosen layout variant and modify specific aspects via arguments, such as using `useWideButton` in `_forgotPasswordScreenContent` or `showImageInForm` in `_loginScreenContent`. Not sure if it is needed, but looks a bit "cleaner" as for me.
  
  
# TODO (in next PRs)
* Replace the big background image, because the current one is to small.
* Sync with Aleš about Snackbar width. Currently they occupy the full width and I am not sure how to handle it correctly.

# Example
* I have published this branch on dev web variant https://zachran-jidlo.github.io/zachranobed-web-dev/.

https://github.com/user-attachments/assets/11167c08-497e-402a-8756-680e2c6dd12f


  