### PR TITLE
ZOB-289 Adjust web layout for detail and form screens | Merge after #160

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is a changelog for **ZachranObed** application.
 - **ZOB-273** Adjust web layout for login screen.
 - **ZOB-286** Adjust web layout for delivery info banner.
 - **ZOB-288** Adjust web layout for profile, contacts, change password and debug screens.
+- **ZOB-289** Adjust web layout for detail and form screens.
 
 ### Removed
 

--- a/lib/features/debug/debug_screen.dart
+++ b/lib/features/debug/debug_screen.dart
@@ -1,10 +1,9 @@
 import 'package:auto_route/annotations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_material_symbols/flutter_material_symbols.dart';
-import 'package:zachranobed/common/constants.dart';
 import 'package:zachranobed/common/logger/zo_logger.dart';
-import 'package:zachranobed/ui/widgets/adaptive_content.dart';
 import 'package:zachranobed/ui/widgets/button.dart';
+import 'package:zachranobed/ui/widgets/screen_scaffold.dart';
 
 @RoutePage()
 class DebugScreen extends StatelessWidget {
@@ -12,44 +11,27 @@ class DebugScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(
-        child: AdaptiveContent(
-          web: (context) {
-            return Center(
-              child: SizedBox(
-                width: LayoutStyle.webBreakpoint.toDouble(),
-                child: _debugScreenContent(),
-              ),
-            );
-          },
-          mobile: (context) => _debugScreenContent(),
+    return ScreenScaffold.universal(
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text("Debug Screen"),
         ),
-      ),
-    );
-  }
-
-  /// Builds the content of the debug screen.
-  Widget _debugScreenContent() {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text("Debug Screen"),
-      ),
-      body: SafeArea(
-        child: SingleChildScrollView(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Column(
-              children: <Widget>[
-                ZOButton(
-                  text: "Test log",
-                  icon: MaterialSymbols.bug_report,
-                  onPressed: () {
-                    ZOLogger.logMessage(
-                        "This is a debug message to the logger to verify, how the logger works");
-                  },
-                ),
-              ],
+        body: SafeArea(
+          child: SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Column(
+                children: <Widget>[
+                  ZOButton(
+                    text: "Test log",
+                    icon: MaterialSymbols.bug_report,
+                    onPressed: () {
+                      ZOLogger.logMessage(
+                          "This is a debug message to the logger to verify, how the logger works");
+                    },
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/features/foodboxes/presentation/screen/box_movement_detail_screen.dart
+++ b/lib/features/foodboxes/presentation/screen/box_movement_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import 'package:zachranobed/common/constants.dart';
 import 'package:zachranobed/extensions/build_context_extensions.dart';
 import 'package:zachranobed/features/foodboxes/domain/model/box_movement.dart';
+import 'package:zachranobed/ui/widgets/screen_scaffold.dart';
 import 'package:zachranobed/ui/widgets/snackbar/persistent_snackbar.dart';
 import 'package:zachranobed/ui/widgets/supporting_text.dart';
 import 'package:zachranobed/ui/widgets/text_field.dart';
@@ -20,43 +21,45 @@ class BoxMovementDetailScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final countPrefix = boxMovement.count > 0 ? '+' : '';
-    return Scaffold(
-      appBar: AppBar(),
-      body: SingleChildScrollView(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(
-            horizontal: WidgetStyle.padding,
-          ),
-          child: Column(
-            children: <Widget>[
-              Row(
-                children: <Widget>[
-                  Flexible(
-                    child: Text(
-                      boxMovement.type.name,
-                      overflow: TextOverflow.clip,
-                      style: const TextStyle(fontSize: FontSize.l),
+    return ScreenScaffold.universal(
+      child: Scaffold(
+        appBar: AppBar(),
+        body: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: WidgetStyle.padding,
+            ),
+            child: Column(
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    Flexible(
+                      child: Text(
+                        boxMovement.type.name,
+                        overflow: TextOverflow.clip,
+                        style: const TextStyle(fontSize: FontSize.l),
+                      ),
                     ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: GapSize.m),
-              ZOTextField(
-                label: context.l10n!.numberOfBoxes,
-                initialValue: '$countPrefix${boxMovement.count}',
-                readOnly: true,
-              ),
-              const SizedBox(height: GapSize.xs),
-              SupportingText(
-                text: '${context.l10n!.sentOn}'
-                    ' ${DateFormat('d.M.y').format(boxMovement.date)}'
-                    ' ${context.l10n!.atTime}'
-                    ' ${DateFormat('HH:mm').format(boxMovement.date)}.',
-              ),
-              const SizedBox(height: GapSize.xs),
-              ZOPersistentSnackBar(message: context.l10n!.formCantBeEdited),
-              const SizedBox(height: GapSize.m),
-            ],
+                  ],
+                ),
+                const SizedBox(height: GapSize.m),
+                ZOTextField(
+                  label: context.l10n!.numberOfBoxes,
+                  initialValue: '$countPrefix${boxMovement.count}',
+                  readOnly: true,
+                ),
+                const SizedBox(height: GapSize.xs),
+                SupportingText(
+                  text: '${context.l10n!.sentOn}'
+                      ' ${DateFormat('d.M.y').format(boxMovement.date)}'
+                      ' ${context.l10n!.atTime}'
+                      ' ${DateFormat('HH:mm').format(boxMovement.date)}.',
+                ),
+                const SizedBox(height: GapSize.xs),
+                ZOPersistentSnackBar(message: context.l10n!.formCantBeEdited),
+                const SizedBox(height: GapSize.m),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/features/login/presentation/screen/login_screen.dart
+++ b/lib/features/login/presentation/screen/login_screen.dart
@@ -12,10 +12,10 @@ import 'package:zachranobed/extensions/build_context_extensions.dart';
 import 'package:zachranobed/features/login/domain/check_if_devtools_are_enabled_usecase.dart';
 import 'package:zachranobed/routes/app_router.gr.dart';
 import 'package:zachranobed/services/auth_service.dart';
-import 'package:zachranobed/ui/widgets/adaptive_content.dart';
 import 'package:zachranobed/ui/widgets/button.dart';
 import 'package:zachranobed/ui/widgets/clickable_text.dart';
 import 'package:zachranobed/ui/widgets/password_text_field.dart';
+import 'package:zachranobed/ui/widgets/screen_scaffold.dart';
 import 'package:zachranobed/ui/widgets/snackbar/temporary_snackbar.dart';
 import 'package:zachranobed/ui/widgets/text_field.dart';
 
@@ -49,46 +49,39 @@ class _LoginScreenState extends State<LoginScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(
-        child: AdaptiveContent(
-          web: (context) {
-            return Row(
-              children: [
-                Expanded(
-                  child: GestureDetector(
-                    onLongPress: showDebugScreenIfPossible,
-                    // TODO (Alex) Use another image with better quality
-                    child: Image.asset(
-                      ZOStrings.foodImagePath,
-                      fit: BoxFit.cover,
-                      height: double.infinity,
-                      opacity: const AlwaysStoppedAnimation(.2),
-                    ),
+    return ScreenScaffold(
+      centerWebLayout: false,
+      web: (context) {
+        return Row(
+          children: [
+            Expanded(
+              child: GestureDetector(
+                onLongPress: showDebugScreenIfPossible,
+                // TODO (Alex) Use another image with better quality
+                child: Image.asset(
+                  ZOStrings.foodImagePath,
+                  fit: BoxFit.cover,
+                  height: double.infinity,
+                  opacity: const AlwaysStoppedAnimation(.2),
+                ),
+              ),
+            ),
+            Material(
+              elevation: 8,
+              child: SizedBox(
+                width: LayoutStyle.loginFormWidth.toDouble(),
+                child: Center(
+                  child: _loginScreenContent(
+                    showImageInForm: false,
+                    padding: const EdgeInsets.all(72.0),
                   ),
                 ),
-                Material(
-                  elevation: 8,
-                  child: SizedBox(
-                    width: LayoutStyle.loginFormWidth.toDouble(),
-                    child: Center(
-                      child: _loginScreenContent(
-                        showImageInForm: false,
-                        padding: const EdgeInsets.all(72.0),
-                      ),
-                    ),
-                  ),
-                ),
-              ],
-            );
-          },
-          mobile: (context) {
-            return _loginScreenContent(
-              showImageInForm: true,
-            );
-          },
-        ),
-      ),
+              ),
+            ),
+          ],
+        );
+      },
+      mobile: (context) => _loginScreenContent(showImageInForm: true),
     );
   }
 
@@ -147,7 +140,7 @@ class _LoginScreenState extends State<LoginScreen> {
               ),
             ),
           ),
-          const SizedBox(height: GapSize.m),
+          const SizedBox(height: GapSize.xs),
           ZOClickableText(
             clickableText: context.l10n!.forgotPassword,
             color: ZOColors.onPrimaryLight,

--- a/lib/features/menu/presentation/contacts_screen.dart
+++ b/lib/features/menu/presentation/contacts_screen.dart
@@ -1,6 +1,5 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:collection/collection.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:zachranobed/common/constants.dart';
@@ -10,10 +9,10 @@ import 'package:zachranobed/extensions/build_context_extensions.dart';
 import 'package:zachranobed/features/menu/domain/model/contact.dart';
 import 'package:zachranobed/features/menu/domain/model/contacts_summary.dart';
 import 'package:zachranobed/features/menu/domain/usecase/get_contacts_use_case.dart';
-import 'package:zachranobed/ui/widgets/adaptive_content.dart';
 import 'package:zachranobed/ui/widgets/contact_row.dart';
 import 'package:zachranobed/ui/widgets/error_content.dart';
 import 'package:zachranobed/ui/widgets/menu/menu_section.dart';
+import 'package:zachranobed/ui/widgets/screen_scaffold.dart';
 
 /// A screen that displays a list of contacts.
 @RoutePage()
@@ -36,38 +35,21 @@ class _ContactsScreenState extends State<ContactsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(
-        child: AdaptiveContent(
-          web: (context) {
-            return Center(
-              child: SizedBox(
-                width: LayoutStyle.webBreakpoint.toDouble(),
-                child: _contactsScreenContent(),
-              ),
-            );
+    return ScreenScaffold.universal(
+      child: Scaffold(
+        appBar: AppBar(),
+        body: FutureBuilder(
+          future: _contactsFuture,
+          builder:
+              (BuildContext context, AsyncSnapshot<ContactsSummary> snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return _loading();
+            } else if (snapshot.hasError || snapshot.data == null) {
+              return _error(context);
+            }
+            return _contacts(snapshot.data!);
           },
-          mobile: (context) => _contactsScreenContent(),
         ),
-      ),
-    );
-  }
-
-  /// Builds the content of the contacts screen.
-  Widget _contactsScreenContent() {
-    return Scaffold(
-      appBar: AppBar(),
-      body: FutureBuilder(
-        future: _contactsFuture,
-        builder:
-            (BuildContext context, AsyncSnapshot<ContactsSummary> snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return _loading();
-          } else if (snapshot.hasError || snapshot.data == null) {
-            return _error(context);
-          }
-          return _contacts(snapshot.data!);
-        },
       ),
     );
   }

--- a/lib/features/menu/presentation/menu_screen.dart
+++ b/lib/features/menu/presentation/menu_screen.dart
@@ -10,12 +10,12 @@ import 'package:zachranobed/extensions/build_context_extensions.dart';
 import 'package:zachranobed/features/login/domain/check_if_devtools_are_enabled_usecase.dart';
 import 'package:zachranobed/routes/app_router.gr.dart';
 import 'package:zachranobed/services/auth_service.dart';
-import 'package:zachranobed/ui/widgets/adaptive_content.dart';
 import 'package:zachranobed/ui/widgets/button.dart';
 import 'package:zachranobed/ui/widgets/menu/menu_button.dart';
 import 'package:zachranobed/ui/widgets/menu/menu_item.dart';
 import 'package:zachranobed/ui/widgets/menu/menu_section.dart';
 import 'package:zachranobed/ui/widgets/menu/menu_user_info.dart';
+import 'package:zachranobed/ui/widgets/screen_scaffold.dart';
 
 @RoutePage()
 class MenuScreen extends StatefulWidget {
@@ -46,26 +46,9 @@ class _MenuScreenState extends State<MenuScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(
-        child: AdaptiveContent(
-          web: (context) {
-            return Center(
-              child: SizedBox(
-                width: LayoutStyle.webBreakpoint.toDouble(),
-                child: _menuScreenContent(
-                  useWideButton: false,
-                ),
-              ),
-            );
-          },
-          mobile: (context) {
-            return _menuScreenContent(
-              useWideButton: true,
-            );
-          },
-        ),
-      ),
+    return ScreenScaffold(
+      web: (context) => _menuScreenContent(useWideButton: false),
+      mobile: (context) => _menuScreenContent(useWideButton: true),
     );
   }
 

--- a/lib/features/offeredfood/presentation/screens/donated_food_detail_screen.dart
+++ b/lib/features/offeredfood/presentation/screens/donated_food_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import 'package:zachranobed/common/constants.dart';
 import 'package:zachranobed/extensions/build_context_extensions.dart';
 import 'package:zachranobed/features/offeredfood/domain/model/offered_food.dart';
+import 'package:zachranobed/ui/widgets/screen_scaffold.dart';
 import 'package:zachranobed/ui/widgets/snackbar/persistent_snackbar.dart';
 import 'package:zachranobed/ui/widgets/supporting_text.dart';
 import 'package:zachranobed/ui/widgets/text_field.dart';
@@ -16,74 +17,76 @@ class DonatedFoodDetailScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(),
-      body: SingleChildScrollView(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(
-            horizontal: WidgetStyle.padding,
-          ),
-          child: Column(
-            children: <Widget>[
-              Row(
-                children: <Widget>[
-                  Flexible(
-                    child: Text(
-                      offeredFood.dishName,
-                      overflow: TextOverflow.clip,
-                      style: const TextStyle(fontSize: FontSize.l),
+    return ScreenScaffold.universal(
+      child: Scaffold(
+        appBar: AppBar(),
+        body: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: WidgetStyle.padding,
+            ),
+            child: Column(
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    Flexible(
+                      child: Text(
+                        offeredFood.dishName,
+                        overflow: TextOverflow.clip,
+                        style: const TextStyle(fontSize: FontSize.l),
+                      ),
                     ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: GapSize.m),
-              ZOTextField(
-                label: context.l10n!.allergens,
-                initialValue: offeredFood.allergens.join(", "),
-                readOnly: true,
-              ),
-              _buildGap(),
-              ZOTextField(
-                label: context.l10n!.foodCategory,
-                initialValue: offeredFood.foodCategory,
-                readOnly: true,
-              ),
-              _buildGap(),
-              ZOTextField(
-                label: context.l10n!.numberOfServings,
-                initialValue: offeredFood.numberOfServings.toString(),
-                readOnly: true,
-              ),
-              _buildGap(),
-              ZOTextField(
-                label: context.l10n!.numberOfBoxes,
-                initialValue: offeredFood.numberOfBoxes.toString(),
-                readOnly: true,
-              ),
-              _buildGap(),
-              ZOTextField(
-                label: context.l10n!.boxType,
-                initialValue: offeredFood.boxType,
-                readOnly: true,
-              ),
-              _buildGap(),
-              ZOTextField(
-                label: context.l10n!.consumeBy,
-                initialValue:
-                    DateFormat('d.M.y HH:mm').format(offeredFood.consumeBy),
-                readOnly: true,
-              ),
-              const SizedBox(height: GapSize.xs),
-              SupportingText(
-                text: '${context.l10n!.donatedOn}'
-                    ' ${DateFormat('d.M.y').format(offeredFood.date)}'
-                    ' ${context.l10n!.atTime}'
-                    ' ${DateFormat('HH:mm').format(offeredFood.date)}.',
-              ),
-              const SizedBox(height: GapSize.xs),
-              ZOPersistentSnackBar(message: context.l10n!.formCantBeEdited),
-              const SizedBox(height: GapSize.m),
-            ],
+                  ],
+                ),
+                const SizedBox(height: GapSize.m),
+                ZOTextField(
+                  label: context.l10n!.allergens,
+                  initialValue: offeredFood.allergens.join(", "),
+                  readOnly: true,
+                ),
+                _buildGap(),
+                ZOTextField(
+                  label: context.l10n!.foodCategory,
+                  initialValue: offeredFood.foodCategory,
+                  readOnly: true,
+                ),
+                _buildGap(),
+                ZOTextField(
+                  label: context.l10n!.numberOfServings,
+                  initialValue: offeredFood.numberOfServings.toString(),
+                  readOnly: true,
+                ),
+                _buildGap(),
+                ZOTextField(
+                  label: context.l10n!.numberOfBoxes,
+                  initialValue: offeredFood.numberOfBoxes.toString(),
+                  readOnly: true,
+                ),
+                _buildGap(),
+                ZOTextField(
+                  label: context.l10n!.boxType,
+                  initialValue: offeredFood.boxType,
+                  readOnly: true,
+                ),
+                _buildGap(),
+                ZOTextField(
+                  label: context.l10n!.consumeBy,
+                  initialValue:
+                      DateFormat('d.M.y HH:mm').format(offeredFood.consumeBy),
+                  readOnly: true,
+                ),
+                const SizedBox(height: GapSize.xs),
+                SupportingText(
+                  text: '${context.l10n!.donatedOn}'
+                      ' ${DateFormat('d.M.y').format(offeredFood.date)}'
+                      ' ${context.l10n!.atTime}'
+                      ' ${DateFormat('HH:mm').format(offeredFood.date)}.',
+                ),
+                const SizedBox(height: GapSize.xs),
+                ZOPersistentSnackBar(message: context.l10n!.formCantBeEdited),
+                const SizedBox(height: GapSize.m),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/ui/screens/change_password_screen.dart
+++ b/lib/ui/screens/change_password_screen.dart
@@ -7,9 +7,9 @@ import 'package:zachranobed/common/utils/field_validation_utils.dart';
 import 'package:zachranobed/extensions/build_context_extensions.dart';
 import 'package:zachranobed/routes/app_router.gr.dart';
 import 'package:zachranobed/services/auth_service.dart';
-import 'package:zachranobed/ui/widgets/adaptive_content.dart';
 import 'package:zachranobed/ui/widgets/button.dart';
 import 'package:zachranobed/ui/widgets/password_text_field.dart';
+import 'package:zachranobed/ui/widgets/screen_scaffold.dart';
 import 'package:zachranobed/ui/widgets/snackbar/temporary_snackbar.dart';
 
 @RoutePage()
@@ -40,26 +40,9 @@ class _ChangePasswordScreenState extends State<ChangePasswordScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(
-        child: AdaptiveContent(
-          web: (context) {
-            return Center(
-              child: SizedBox(
-                width: LayoutStyle.webBreakpoint.toDouble(),
-                child: _changePasswordScreenContent(
-                  useWideButton: false,
-                ),
-              ),
-            );
-          },
-          mobile: (context) {
-            return _changePasswordScreenContent(
-              useWideButton: true,
-            );
-          },
-        ),
-      ),
+    return ScreenScaffold(
+      web: (context) => _changePasswordScreenContent(useWideButton: false),
+      mobile: (context) => _changePasswordScreenContent(useWideButton: true),
     );
   }
 

--- a/lib/ui/screens/forgot_password_screen.dart
+++ b/lib/ui/screens/forgot_password_screen.dart
@@ -7,8 +7,8 @@ import 'package:zachranobed/common/utils/field_validation_utils.dart';
 import 'package:zachranobed/extensions/build_context_extensions.dart';
 import 'package:zachranobed/routes/app_router.gr.dart';
 import 'package:zachranobed/services/auth_service.dart';
-import 'package:zachranobed/ui/widgets/adaptive_content.dart';
 import 'package:zachranobed/ui/widgets/button.dart';
+import 'package:zachranobed/ui/widgets/screen_scaffold.dart';
 import 'package:zachranobed/ui/widgets/snackbar/temporary_snackbar.dart';
 import 'package:zachranobed/ui/widgets/text_field.dart';
 
@@ -35,26 +35,9 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(
-        child: AdaptiveContent(
-          web: (context) {
-            return Center(
-              child: SizedBox(
-                width: LayoutStyle.webBreakpoint.toDouble(),
-                child: _forgotPasswordScreenContent(
-                  useWideButton: false,
-                ),
-              ),
-            );
-          },
-          mobile: (context) {
-            return _forgotPasswordScreenContent(
-              useWideButton: true,
-            );
-          },
-        ),
-      ),
+    return ScreenScaffold(
+      web: (context) => _forgotPasswordScreenContent(useWideButton: false),
+      mobile: (context) => _forgotPasswordScreenContent(useWideButton: true),
     );
   }
 

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -14,8 +14,8 @@ import 'package:zachranobed/notifiers/user_notifier.dart';
 import 'package:zachranobed/routes/app_router.gr.dart';
 import 'package:zachranobed/services/auth_service.dart';
 import 'package:zachranobed/ui/screens/overview_screen.dart';
-import 'package:zachranobed/ui/widgets/adaptive_content.dart';
 import 'package:zachranobed/ui/widgets/button.dart';
+import 'package:zachranobed/ui/widgets/screen_scaffold.dart';
 import 'package:zachranobed/ui/widgets/svg_icon.dart';
 
 @RoutePage()
@@ -101,85 +101,82 @@ class _HomeScreenState extends State<HomeScreen>
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(
-        child: AdaptiveContent(
-          web: (context) {
-            return Row(
-              children: [
-                NavigationDrawer(
-                  indicatorColor: ZOColors.secondary,
-                  onDestinationSelected: (i) {
-                    _tabController.animateTo(i);
-                  },
-                  selectedIndex: _selectedIndex,
-                  children: <Widget>[
-                    Padding(
-                      padding: const EdgeInsets.fromLTRB(24, 42, 40, 52),
-                      child: SvgPicture.asset(ZOStrings.zoLogoPath, width: 180),
-                    ),
-                    ..._tabs.map(
-                      (data) {
-                        return NavigationDrawerDestination(
-                          label: DefaultTextStyle.merge(
-                            style: const TextStyle(
-                              color: ZOColors.onSecondary,
-                            ),
-                            child: data.label(context),
-                          ),
-                          icon: IconTheme.merge(
-                            data: const IconThemeData(
-                              size: 24.0,
-                              color: ZOColors.onSecondary,
-                            ),
-                            child: data.icon(context),
-                          ),
-                        );
-                      },
-                    ),
-                  ],
+    return ScreenScaffold(
+      centerWebLayout: false,
+      web: (context) {
+        return Row(
+          children: [
+            NavigationDrawer(
+              indicatorColor: ZOColors.secondary,
+              onDestinationSelected: (i) {
+                _tabController.animateTo(i);
+              },
+              selectedIndex: _selectedIndex,
+              children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(24, 42, 40, 52),
+                  child: SvgPicture.asset(ZOStrings.zoLogoPath, width: 180),
                 ),
-                Expanded(
-                  child: Center(
-                    child: SizedBox(
-                        width: LayoutStyle.webBreakpoint.toDouble(),
-                        child: _homeScreenContent()),
-                  ),
+                ..._tabs.map(
+                  (data) {
+                    return NavigationDrawerDestination(
+                      label: DefaultTextStyle.merge(
+                        style: const TextStyle(
+                          color: ZOColors.onSecondary,
+                        ),
+                        child: data.label(context),
+                      ),
+                      icon: IconTheme.merge(
+                        data: const IconThemeData(
+                          size: 24.0,
+                          color: ZOColors.onSecondary,
+                        ),
+                        child: data.icon(context),
+                      ),
+                    );
+                  },
                 ),
               ],
-            );
-          },
-          mobile: (context) {
-            return Scaffold(
-              body: _homeScreenContent(),
-              bottomNavigationBar: SizedBox(
-                height: 90.0,
-                child: Material(
-                  color: ZOColors.primaryLight,
-                  child: TabBar(
-                    controller: _tabController,
-                    splashFactory: NoSplash.splashFactory,
-                    overlayColor: WidgetStateProperty.resolveWith<Color?>(
-                        (Set<WidgetState> states) {
-                      return states.contains(WidgetState.focused)
-                          ? null
-                          : Colors.transparent;
-                    }),
-                    unselectedLabelColor: ZOColors.onPrimaryLight,
-                    indicatorColor: Colors.transparent,
-                    tabs: _tabs.map((data) {
-                      return Tab(
-                        icon: data.icon(context),
-                        child: data.label(context),
-                      );
-                    }).toList(),
-                  ),
-                ),
+            ),
+            Expanded(
+              child: Center(
+                child: SizedBox(
+                    width: LayoutStyle.webBreakpoint.toDouble(),
+                    child: _homeScreenContent()),
               ),
-            );
-          },
-        ),
-      ),
+            ),
+          ],
+        );
+      },
+      mobile: (context) {
+        return Scaffold(
+          body: _homeScreenContent(),
+          bottomNavigationBar: SizedBox(
+            height: 90.0,
+            child: Material(
+              color: ZOColors.primaryLight,
+              child: TabBar(
+                controller: _tabController,
+                splashFactory: NoSplash.splashFactory,
+                overlayColor: WidgetStateProperty.resolveWith<Color?>(
+                    (Set<WidgetState> states) {
+                  return states.contains(WidgetState.focused)
+                      ? null
+                      : Colors.transparent;
+                }),
+                unselectedLabelColor: ZOColors.onPrimaryLight,
+                indicatorColor: Colors.transparent,
+                tabs: _tabs.map((data) {
+                  return Tab(
+                    icon: data.icon(context),
+                    child: data.label(context),
+                  );
+                }).toList(),
+              ),
+            ),
+          ),
+        );
+      },
     );
   }
 

--- a/lib/ui/screens/offer_food_overview_screen.dart
+++ b/lib/ui/screens/offer_food_overview_screen.dart
@@ -13,7 +13,8 @@ import 'package:zachranobed/features/offeredfood/domain/repository/offered_food_
 import 'package:zachranobed/notifiers/delivery_notifier.dart';
 import 'package:zachranobed/routes/app_router.gr.dart';
 import 'package:zachranobed/ui/widgets/button.dart';
-import 'package:zachranobed/ui/widgets/info_text_banner.dart';
+import 'package:zachranobed/ui/widgets/info_banner.dart';
+import 'package:zachranobed/ui/widgets/screen_scaffold.dart';
 import 'package:zachranobed/ui/widgets/snackbar/temporary_snackbar.dart';
 import 'package:zachranobed/ui/widgets/trailing_icon_row.dart';
 
@@ -62,71 +63,72 @@ class _OfferFoodOverviewScreenState extends State<OfferFoodOverviewScreen> {
 
   @override
   Widget build(BuildContext context) {
+    return ScreenScaffold(
+      web: (context) => _offerFoodOverviewScreenContent(useWideButton: false),
+      mobile: (context) => _offerFoodOverviewScreenContent(useWideButton: true),
+    );
+  }
+
+  /// Builds the content of the offer food overview screen.
+  ///
+  /// The [useWideButton] parameter determines whether to stretch confirmation
+  /// button to screen width.
+  Widget _offerFoodOverviewScreenContent({
+    required bool useWideButton,
+  }) {
     return PopScope(
-        canPop: false,
-        onPopInvoked: (bool didPop) async {
-          Navigator.popUntil(context, ModalRoute.withName(OfferFoodRoute.name));
-        },
-        child: Scaffold(
-            appBar: AppBar(),
-            body: Column(children: [
-              Container(
-                padding: const EdgeInsets.all(WidgetStyle.padding),
-                alignment: Alignment.centerLeft,
-                child: Text(
-                  context.l10n!.offerFoodOverviewScreenTitle,
-                  style: Theme.of(context).textTheme.titleLarge,
-                  textAlign: TextAlign.left,
-                  overflow: TextOverflow.clip,
-                ),
+      canPop: false,
+      onPopInvoked: (bool didPop) async {
+        Navigator.popUntil(context, ModalRoute.withName(OfferFoodRoute.name));
+      },
+      child: Scaffold(
+        appBar: AppBar(),
+        body: Column(
+          children: [
+            Container(
+              padding: const EdgeInsets.all(WidgetStyle.padding),
+              alignment: Alignment.centerLeft,
+              child: Text(
+                context.l10n!.offerFoodOverviewScreenTitle,
+                style: Theme.of(context).textTheme.titleLarge,
+                textAlign: TextAlign.left,
+                overflow: TextOverflow.clip,
               ),
-              InfoTextBanner(message: context.l10n!.offerFoodOverviewBanner),
-              const SizedBox(height: GapSize.m),
-              if (_isLoading)
-                const Center(child: CircularProgressIndicator())
-              else
-                Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: WidgetStyle.padding,
-                  ),
-                  child: Column(children: [
+            ),
+            InfoBanner.text(
+              backgroundColor: ZOColors.amberTransparent,
+              message: context.l10n!.offerFoodOverviewBanner,
+            ),
+            const SizedBox(height: GapSize.m),
+            if (_isLoading)
+              const Center(child: CircularProgressIndicator())
+            else
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: WidgetStyle.padding,
+                ),
+                child: Column(
+                  children: [
                     _offerFoodListSection(context,
                         foodInfos: foodInfos, foodBoxTypes: _foodBoxTypes),
                     const SizedBox(height: GapSize.m),
-                    ZOButton(
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: ZOButton(
                         text: context.l10n!.offerFood,
-                        onPressed: () async {
-                          showDialog(
-                            context: context,
-                            barrierDismissible: false,
-                            builder: (context) => const Center(
-                                child: CircularProgressIndicator()),
-                          );
-
-                          if (await foodInfos.verifyAvailableBoxCount(
-                              context, _foodBoxRepository)) {
-                            final isSuccess = await _offerFood();
-                            if (context.mounted) {
-                              context.router.replace(ThankYouRoute(
-                                isSuccess: isSuccess,
-                                message: context.l10n!.foodDonationConfirmation,
-                              ));
-                            }
-                          } else {
-                            if (context.mounted) {
-                              Navigator.pop(context);
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                ZOTemporarySnackBar(
-                                  backgroundColor: Colors.red,
-                                  message: context.l10n!.boxCountError,
-                                ),
-                              );
-                            }
-                          }
-                        })
-                  ]),
-                )
-            ])));
+                        minimumSize: ZOButtonSize.large(
+                          fullWidth: useWideButton,
+                        ),
+                        onPressed: _onConfirmationButtonPressed,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
   }
 
   Future<bool> _offerFood() async {
@@ -138,6 +140,34 @@ class _OfferFoodOverviewScreenState extends State<OfferFoodOverviewScreen> {
       delivery: delivery,
       foodInfo: foodInfos,
     );
+  }
+
+  void _onConfirmationButtonPressed() async {
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => const Center(child: CircularProgressIndicator()),
+    );
+
+    if (await foodInfos.verifyAvailableBoxCount(context, _foodBoxRepository)) {
+      final isSuccess = await _offerFood();
+      if (mounted) {
+        context.router.replace(ThankYouRoute(
+          isSuccess: isSuccess,
+          message: context.l10n!.foodDonationConfirmation,
+        ));
+      }
+    } else {
+      if (mounted) {
+        Navigator.pop(context);
+        ScaffoldMessenger.of(context).showSnackBar(
+          ZOTemporarySnackBar(
+            backgroundColor: Colors.red,
+            message: context.l10n!.boxCountError,
+          ),
+        );
+      }
+    }
   }
 }
 

--- a/lib/ui/screens/offer_food_screen.dart
+++ b/lib/ui/screens/offer_food_screen.dart
@@ -12,6 +12,7 @@ import 'package:zachranobed/ui/widgets/button.dart';
 import 'package:zachranobed/ui/widgets/dialog.dart';
 import 'package:zachranobed/ui/widgets/food_section_fields.dart';
 import 'package:zachranobed/ui/widgets/form/form_validation_manager.dart';
+import 'package:zachranobed/ui/widgets/screen_scaffold.dart';
 import 'package:zachranobed/ui/widgets/snackbar/temporary_snackbar.dart';
 
 @RoutePage()
@@ -87,6 +88,19 @@ class _OfferFoodScreenState extends State<OfferFoodScreen> {
 
   @override
   Widget build(BuildContext context) {
+    return ScreenScaffold(
+      web: (context) => _offerFoodScreenContent(useWideButton: false),
+      mobile: (context) => _offerFoodScreenContent(useWideButton: true),
+    );
+  }
+
+  /// Builds the content of the offer food screen.
+  ///
+  /// The [useWideButton] parameter determines whether to stretch confirmation
+  /// button to screen width.
+  Widget _offerFoodScreenContent({
+    required bool useWideButton,
+  }) {
     return WillPopScope(
       onWillPop: _showConfirmationDialog,
       child: Scaffold(
@@ -120,32 +134,16 @@ class _OfferFoodScreenState extends State<OfferFoodScreen> {
                       ),
                       _addAnotherFoodButton(),
                       const SizedBox(height: GapSize.xxl),
-                      ZOButton(
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: ZOButton(
                           text: context.l10n!.continueTheOffer,
-                          onPressed: () async {
-                            if (_formKey.currentState!.validate()) {
-                              if (await _foodSections.verifyAvailableBoxCount(
-                                  context, _foodBoxRepository)) {
-                                if (mounted) {
-                                  context.router.navigate(
-                                    OfferFoodOverviewRoute(
-                                        foodInfos: _foodSections),
-                                  );
-                                }
-                              } else {
-                                if (mounted) {
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                    ZOTemporarySnackBar(
-                                      backgroundColor: Colors.red,
-                                      message: context.l10n!.boxCountError,
-                                    ),
-                                  );
-                                }
-                              }
-                            } else {
-                              _formValidationManager.scrollToFirstError();
-                            }
-                          }),
+                          minimumSize: ZOButtonSize.large(
+                            fullWidth: useWideButton,
+                          ),
+                          onPressed: _onConfirmationButtonPressed,
+                        ),
+                      ),
                       const SizedBox(height: GapSize.l),
                     ],
                   ),
@@ -172,5 +170,29 @@ class _OfferFoodScreenState extends State<OfferFoodScreen> {
         });
       },
     );
+  }
+
+  void _onConfirmationButtonPressed() async {
+    if (_formKey.currentState!.validate()) {
+      if (await _foodSections.verifyAvailableBoxCount(
+          context, _foodBoxRepository)) {
+        if (mounted) {
+          context.router.navigate(
+            OfferFoodOverviewRoute(foodInfos: _foodSections),
+          );
+        }
+      } else {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            ZOTemporarySnackBar(
+              backgroundColor: Colors.red,
+              message: context.l10n!.boxCountError,
+            ),
+          );
+        }
+      }
+    } else {
+      _formValidationManager.scrollToFirstError();
+    }
   }
 }

--- a/lib/ui/screens/order_shipping_of_boxes_screen.dart
+++ b/lib/ui/screens/order_shipping_of_boxes_screen.dart
@@ -12,6 +12,7 @@ import 'package:zachranobed/models/charity.dart';
 import 'package:zachranobed/routes/app_router.gr.dart';
 import 'package:zachranobed/ui/widgets/button.dart';
 import 'package:zachranobed/ui/widgets/dialog.dart';
+import 'package:zachranobed/ui/widgets/screen_scaffold.dart';
 import 'package:zachranobed/ui/widgets/shipping_of_boxes_section_fields.dart';
 import 'package:zachranobed/ui/widgets/snackbar/temporary_snackbar.dart';
 
@@ -70,6 +71,19 @@ class _OrderShippingOfBoxesScreenState
 
   @override
   Widget build(BuildContext context) {
+    return ScreenScaffold(
+      web: (context) => _orderBoxShippingScreenContent(useWideButton: false),
+      mobile: (context) => _orderBoxShippingScreenContent(useWideButton: true),
+    );
+  }
+
+  /// Builds the content of the order box shipping screen.
+  ///
+  /// The [useWideButton] parameter determines whether to stretch confirmation
+  /// button to screen width.
+  Widget _orderBoxShippingScreenContent({
+    required bool useWideButton,
+  }) {
     return WillPopScope(
       onWillPop: _showConfirmationDialog,
       child: Scaffold(
@@ -110,34 +124,16 @@ class _OrderShippingOfBoxesScreenState
                         },
                       ),
                       const SizedBox(height: GapSize.xxl),
-                      ZOButton(
-                        text: context.l10n!.orderShipping,
-                        icon: MaterialSymbols.check,
-                        onPressed: () async {
-                          if (_formKey.currentState!.validate()) {
-                            if (await _verifyAvailableBoxCount()) {
-                              final isSuccess = await _orderShipping();
-                              if (mounted) {
-                                context.router.replace(
-                                  ThankYouRoute(
-                                    isSuccess: isSuccess,
-                                    message:
-                                        context.l10n!.shippingOrderConfirmation,
-                                  ),
-                                );
-                              }
-                            } else {
-                              if (mounted) {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  ZOTemporarySnackBar(
-                                    backgroundColor: Colors.red,
-                                    message: context.l10n!.boxCountError,
-                                  ),
-                                );
-                              }
-                            }
-                          }
-                        },
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: ZOButton(
+                          text: context.l10n!.orderShipping,
+                          icon: MaterialSymbols.check,
+                          minimumSize: ZOButtonSize.large(
+                            fullWidth: useWideButton,
+                          ),
+                          onPressed: _onConfirmationButtonPressed,
+                        ),
                       ),
                       const SizedBox(height: 50),
                     ],
@@ -149,6 +145,32 @@ class _OrderShippingOfBoxesScreenState
         ),
       ),
     );
+  }
+
+  void _onConfirmationButtonPressed() async {
+    if (_formKey.currentState!.validate()) {
+      if (await _verifyAvailableBoxCount()) {
+        final isSuccess = await _orderShipping();
+        if (mounted) {
+          context.router.replace(
+            ThankYouRoute(
+              isSuccess: isSuccess,
+              message:
+              context.l10n!.shippingOrderConfirmation,
+            ),
+          );
+        }
+      } else {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            ZOTemporarySnackBar(
+              backgroundColor: Colors.red,
+              message: context.l10n!.boxCountError,
+            ),
+          );
+        }
+      }
+    }
   }
 
   Future<bool> _verifyAvailableBoxCount() async {

--- a/lib/ui/widgets/clickable_text.dart
+++ b/lib/ui/widgets/clickable_text.dart
@@ -20,22 +20,25 @@ class ZOClickableText extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: onTap,
-      child: RichText(
-        text: TextSpan(
-          children: [
-            TextSpan(
-              text: prefixText,
-              style: const TextStyle(color: Colors.black),
-            ),
-            TextSpan(
-              text: clickableText,
-              style: TextStyle(
-                color: color,
-                decoration: underline ? TextDecoration.underline : null,
-                decorationColor: color,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 10.0),
+        child: RichText(
+          text: TextSpan(
+            children: [
+              TextSpan(
+                text: prefixText,
+                style: const TextStyle(color: Colors.black),
               ),
-            ),
-          ],
+              TextSpan(
+                text: clickableText,
+                style: TextStyle(
+                  color: color,
+                  decoration: underline ? TextDecoration.underline : null,
+                  decorationColor: color,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/ui/widgets/delivery_info_banner.dart
+++ b/lib/ui/widgets/delivery_info_banner.dart
@@ -54,7 +54,7 @@ class DeliveryInfoBanner extends StatelessWidget {
     return SliverToBoxAdapter(
       child: InfoBanner(
         backgroundColor: ZOColors.successLight,
-        message: (textAlign) {
+        message: (context, textAlign) {
           return Text.rich(
             textAlign: textAlign,
             TextSpan(
@@ -83,7 +83,7 @@ class DeliveryInfoBanner extends StatelessWidget {
     return SliverToBoxAdapter(
       child: InfoBanner(
         backgroundColor: ZOColors.successLight,
-        message: (textAlign) {
+        message: (context, textAlign) {
           return DonationCountdownTimer(
             delivery: delivery,
             textAlign: textAlign,

--- a/lib/ui/widgets/info_banner.dart
+++ b/lib/ui/widgets/info_banner.dart
@@ -4,7 +4,7 @@ import 'package:zachranobed/ui/widgets/adaptive_content.dart';
 import 'package:zachranobed/ui/widgets/button.dart';
 
 class InfoBanner extends StatelessWidget {
-  final Widget Function(TextAlign) message;
+  final Widget Function(BuildContext, TextAlign) message;
   final Color backgroundColor;
   final ZOButton? button;
 
@@ -14,6 +14,27 @@ class InfoBanner extends StatelessWidget {
     required this.backgroundColor,
     this.button,
   });
+
+  InfoBanner.text({
+    Key? key,
+    required String message,
+    required Color backgroundColor,
+    Color textColor = ZOColors.onPrimaryLight,
+    int maxLines = 2,
+  }) : this(
+          key: key,
+          backgroundColor: backgroundColor,
+          message: (context, textAlign) {
+            final theme = Theme.of(context).textTheme;
+            return Text(
+              message,
+              style: theme.bodyLarge?.copyWith(color: textColor),
+              maxLines: maxLines,
+              overflow: TextOverflow.ellipsis,
+              textAlign: textAlign,
+            );
+          },
+        );
 
   @override
   Widget build(BuildContext context) {
@@ -39,7 +60,7 @@ class InfoBanner extends StatelessWidget {
               Expanded(
                 child: Padding(
                   padding: const EdgeInsets.symmetric(vertical: 10.0),
-                  child: message(TextAlign.start),
+                  child: message(context, TextAlign.start),
                 ),
               ),
               _button(Axis.horizontal),
@@ -58,7 +79,7 @@ class InfoBanner extends StatelessWidget {
         padding: const EdgeInsets.all(WidgetStyle.padding),
         child: Column(
           children: [
-            message(TextAlign.center),
+            message(context, TextAlign.center),
             _button(Axis.vertical),
           ],
         ),

--- a/lib/ui/widgets/screen_scaffold.dart
+++ b/lib/ui/widgets/screen_scaffold.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:zachranobed/common/constants.dart';
+import 'package:zachranobed/ui/widgets/adaptive_content.dart';
+
+/// A scaffold widget that provides a basic structure for screens.
+///
+/// This widget uses [AdaptiveContent] to display different content on web and
+/// mobile. On web, the content can be optionally centered using the
+/// [centerWebLayout] property.
+class ScreenScaffold extends StatelessWidget {
+  /// Whether to automatically center the web layout.
+  final bool centerWebLayout;
+
+  /// The child to display on the web when the screen width is greater than
+  /// [LayoutStyle.webBreakpoint].
+  final WidgetBuilder web;
+
+  /// The child to display on mobile or when the screen width is less than
+  /// [LayoutStyle.webBreakpoint].
+  final WidgetBuilder mobile;
+
+  /// Creates a new [ScreenScaffold] widget.
+  const ScreenScaffold({
+    super.key,
+    required this.web,
+    required this.mobile,
+    this.centerWebLayout = true,
+  });
+
+  /// Creates a new [ScreenScaffold] widget with the same content for web and
+  /// mobile. This constructor is useful when you want to display the same
+  /// content for both layouts.
+  ScreenScaffold.universal({
+    Key? key,
+    required Widget child,
+  }) : this(key: key, web: (context) => child, mobile: (context) => child);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: AdaptiveContent(
+          web: centerWebLayout ? _webCentered : web,
+          mobile: mobile,
+        ),
+      ),
+    );
+  }
+
+  /// Builds the centered web layout. This method centers the web layout within
+  /// a [SizedBox] with a width of [LayoutStyle.webBreakpoint].
+  Widget _webCentered(BuildContext context) {
+    return Center(
+      child: SizedBox(
+        width: LayoutStyle.webBreakpoint.toDouble(),
+        child: web(context),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
# Description

* Merge after #160
* Jira: https://etnetera.atlassian.net/browse/ZOB-289
* This PR also introduces `ScreenScaffold`, that uses `AdaptiveContent` to display different content on web and mobile.

# Example

<img width="600" alt="image" src="https://github.com/user-attachments/assets/d5941073-d76d-4499-b5f9-f571eeb77772">
<img width="600" alt="image" src="https://github.com/user-attachments/assets/0bfffcd9-28d7-4edd-a5b2-3ce0dcd09661">
<img width="600" alt="image" src="https://github.com/user-attachments/assets/07a4a723-70cd-44f2-a654-97b03556641b">
<img width="600" alt="Screenshot 2024-09-27 at 11 54 53" src="https://github.com/user-attachments/assets/84748fdf-6bd4-4b52-8bc0-87155d02f6a1">
<img width="600" alt="Screenshot 2024-09-27 at 11 55 05" src="https://github.com/user-attachments/assets/99b0caf1-721d-4b68-a723-b993d4b9e2a4">
<img width="600" alt="image" src="https://github.com/user-attachments/assets/023ee34b-7463-4243-9e91-91574635470d">
<img width="600" alt="Screenshot 2024-09-27 at 11 56 09" src="https://github.com/user-attachments/assets/be78b413-7371-48df-85dd-3aab77e723a3">
<img width="600" alt="Screenshot 2024-09-27 at 11 56 12" src="https://github.com/user-attachments/assets/ff9feaf4-6839-44b4-a09c-8c43358d88db">


