### PR TITLE
ZOB-295 Remove updating delivery state to NOT_USED from application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is a changelog for **ZachranObed** application.
 ### Changed
 
 ### Removed
+- **ZOB-295** Remove updating delivery state to NOT_USED from application.
 
 ## [1.2.1]
 ### Changed

--- a/lib/features/offeredfood/data/repository/firebase_offered_food_repository.dart
+++ b/lib/features/offeredfood/data/repository/firebase_offered_food_repository.dart
@@ -71,19 +71,6 @@ class FirebaseOfferedFoodRepository implements OfferedFoodRepository {
   }
 
   @override
-  Future<bool> cancelDelivery({required Delivery delivery}) async {
-    final currentDelivery = await _deliveryService.getDeliveryById(delivery.id);
-    if (currentDelivery?.state == DeliveryStateDto.prepared) {
-      _deliveryService.updateDeliveryState(
-        delivery.id,
-        DeliveryStateDto.notUsed,
-      );
-      return true;
-    }
-    return false;
-  }
-
-  @override
   Future<int> getSavedMealsCount({
     required String entityId,
     int? timePeriod,

--- a/lib/features/offeredfood/domain/repository/offered_food_repository.dart
+++ b/lib/features/offeredfood/domain/repository/offered_food_repository.dart
@@ -25,9 +25,6 @@ abstract class OfferedFoodRepository {
     required DeliveryState state,
   });
 
-  /// Cancels the delivery if it is in prepared state.
-  Future<bool> cancelDelivery({required Delivery delivery});
-
   /// Returns a [Future] that completes with an [int] representing the total
   /// count of saved meals for the specified [timePeriod] and user with given
   /// [entityId].

--- a/lib/notifiers/delivery_notifier.dart
+++ b/lib/notifiers/delivery_notifier.dart
@@ -57,18 +57,10 @@ class DeliveryNotifier extends ChangeNotifier {
     }
   }
 
-  /// Cancels current delivery if it is in prepared state and then triggers a
-  /// notification to inform listeners about the change.
-  Future<void> cancelCurrentDelivery() async {
-    final currentDelivery = _delivery;
-    if (currentDelivery == null) {
-      return;
-    }
-
-    if (await _repository.cancelDelivery(delivery: currentDelivery)) {
-      _delivery = currentDelivery.copyWith(state: DeliveryState.notUsed);
-      notifyListeners();
-    }
+  /// Inform listeners about the change.
+  void refreshDelivery() {
+    // Only update UI listeners, so that "canDonate" flag is reevaluated
+    notifyListeners();
   }
 
   bool canDonate(UserData user) {

--- a/lib/ui/widgets/donation_countdown_timer.dart
+++ b/lib/ui/widgets/donation_countdown_timer.dart
@@ -65,7 +65,7 @@ class _DonationCountdownTimerState extends State<DonationCountdownTimer>
       _ticker?.dispose();
 
       SchedulerBinding.instance.addPostFrameCallback((_) {
-        context.read<DeliveryNotifier>().cancelCurrentDelivery();
+        context.read<DeliveryNotifier>().refreshDelivery();
       });
     }
   }


### PR DESCRIPTION
# Description
* JIRA: https://go.jira.etnetera.cz/browse/ZOB-295
* I have removed call to cancel the delivery in Firebase
* Instead the `notifyListeners()` is called to refresh the UI. When executed all subscribed UI elements will update correctly, because `canDonate()` will return false (thanks to the confirmation time check in `FirebaseOfferedFoodRepository::canDonateFood`).
* See test notes in JIRA

# Example


https://github.com/user-attachments/assets/00b84a71-6847-450b-9842-9a0e72f82228

