### PR TITLE
ZOB-189 Add multi-pair support (aka profile switching)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This is a changelog for **ZachranObed** application.
 
 ## [1.3.0]
 ### Added
+- **ZOB-189** Add multi-pair support for Charity.
 
 ### Fixed
 

--- a/lib/common/di/common_dependency_container.dart
+++ b/lib/common/di/common_dependency_container.dart
@@ -1,5 +1,6 @@
 import 'package:get_it/get_it.dart';
 import 'package:zachranobed/common/domain/check_if_app_terms_should_be_shown_usecase.dart';
+import 'package:zachranobed/common/prefs/app_preferences.dart';
 import 'package:zachranobed/features/appConfiguration/data/get_last_app_terms_version_use_case.dart';
 import 'package:zachranobed/services/auth_service.dart';
 
@@ -8,10 +9,12 @@ class CommonDependencyContainer {
 
   static void setup() {
     GetIt.I.registerFactory<CheckIfAppTermsShouldBeShownUseCase>(
-            () => CheckIfAppTermsShouldBeShownUseCase(
-                GetIt.I<AuthService>(),
-                GetIt.I<GetLastAppTermsVersionUseCase>()
-            )
+      () => CheckIfAppTermsShouldBeShownUseCase(
+        GetIt.I<AuthService>(),
+        GetIt.I<GetLastAppTermsVersionUseCase>(),
+      ),
     );
+
+    GetIt.I.registerSingleton(AppPreferences());
   }
 }

--- a/lib/common/helper_service.dart
+++ b/lib/common/helper_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:provider/provider.dart';
+import 'package:zachranobed/models/entity_pair.dart';
 import 'package:zachranobed/models/user_data.dart';
 import 'package:zachranobed/notifiers/delivery_notifier.dart';
 import 'package:zachranobed/notifiers/user_notifier.dart';
@@ -11,6 +12,11 @@ class HelperService {
   /// otherwise returns `null`.
   static UserData? getCurrentUser(BuildContext context) =>
       context.read<UserNotifier>().user;
+
+  /// Watches a [UserData] representing the current user's data if available,
+  /// otherwise returns `null`.
+  static UserData? watchCurrentUser(BuildContext context) =>
+      context.watch<UserNotifier>().user;
 
   /// Returns an [int] indicating the current week number of the year.
   static int get getCurrentWeekNumber {
@@ -28,7 +34,7 @@ class HelperService {
   /// Returns a [bool] indicating whether the current user is eligible to
   /// donate food.
   static bool canDonate(BuildContext context) {
-    final user = getCurrentUser(context);
+    final user = watchCurrentUser(context);
     if (user == null) {
       return false;
     }
@@ -53,6 +59,23 @@ class HelperService {
       if (user != null) {
         deliveryNotifier.init(user);
       }
+    }
+  }
+
+  /// Updates the active pair for the current user.
+  ///
+  /// Retrieves the current user from the context, updates their active pair
+  /// with the provided [pair], and updates the [UserNotifier] with the modified
+  /// user object.
+  static void updateActivePair(BuildContext context, EntityPair pair) {
+    final user = getCurrentUser(context);
+    if (user == null) {
+      return;
+    }
+
+    final userNotifier = context.read<UserNotifier>();
+    if (context.mounted) {
+      userNotifier.user = user.copyWith(activePair: pair);
     }
   }
 }

--- a/lib/common/helper_service.dart
+++ b/lib/common/helper_service.dart
@@ -74,8 +74,11 @@ class HelperService {
     }
 
     final userNotifier = context.read<UserNotifier>();
+    final deliveryNotifier = context.read<DeliveryNotifier>();
     if (context.mounted) {
-      userNotifier.user = user.copyWith(activePair: pair);
+      final updatedUser = user.copyWith(activePair: pair);
+      userNotifier.user = updatedUser;
+      deliveryNotifier.init(updatedUser);
     }
   }
 }

--- a/lib/common/prefs/app_preferences.dart
+++ b/lib/common/prefs/app_preferences.dart
@@ -1,0 +1,44 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:zachranobed/common/prefs/entity_pair_struct.dart';
+
+/// A wrapper around [SharedPreferences] for managing application preferences.
+class AppPreferences {
+  /// Key for storing the active pair donor ID.
+  static const _keyActivePairDonorId = "KEY_ACTIVE_PAIR_DONOR_ID";
+
+  /// Key for storing the active pair recipient ID.
+  static const _keyActivePairRecipientId = "KEY_ACTIVE_PAIR_RECIPIENT_ID";
+
+  /// Sets the given entity [pair] as active.
+  Future<void> setActivePair(EntityPairStruct pair) async {
+    final prefs = await _prefs();
+    prefs.setString(_keyActivePairDonorId, pair.donorId);
+    prefs.setString(_keyActivePairRecipientId, pair.recipientId);
+  }
+
+  /// Gets the active entity pair. Returns the active entity pair, or `null`
+  /// if no active pair is set.
+  Future<EntityPairStruct?> getActivePair() async {
+    final prefs = await _prefs();
+    final donorId = prefs.getString(_keyActivePairDonorId);
+    final recipientId = prefs.getString(_keyActivePairRecipientId);
+    if (donorId == null || recipientId == null) {
+      return null;
+    }
+    return EntityPairStruct(donorId: donorId, recipientId: recipientId);
+  }
+
+  /// Clears all preferences.
+  ///
+  /// Returns `true` if the preferences were successfully cleared, `false`
+  /// otherwise.
+  Future<bool> clear() async {
+    final prefs = await _prefs();
+    return prefs.clear();
+  }
+
+  /// Gets an instance of [SharedPreferences].
+  Future<SharedPreferences> _prefs() async {
+    return await SharedPreferences.getInstance();
+  }
+}

--- a/lib/common/prefs/entity_pair_struct.dart
+++ b/lib/common/prefs/entity_pair_struct.dart
@@ -1,0 +1,14 @@
+/// Represents an entity pair between donor and recipient (canteen and charity).
+class EntityPairStruct {
+  /// The entity ID of the donor entity.
+  final String donorId;
+
+  /// The entity ID of the recipient entity.
+  final String recipientId;
+
+  /// Creates a new [EntityPairStruct] instance.
+  EntityPairStruct({
+    required this.donorId,
+    required this.recipientId,
+  });
+}

--- a/lib/features/activepair/data/repository/firebase_entity_pairs_repository.dart
+++ b/lib/features/activepair/data/repository/firebase_entity_pairs_repository.dart
@@ -1,0 +1,67 @@
+import 'package:collection/collection.dart';
+import 'package:zachranobed/common/prefs/app_preferences.dart';
+import 'package:zachranobed/common/prefs/entity_pair_struct.dart';
+import 'package:zachranobed/features/activepair/domain/model/entity_pairs_summary.dart';
+import 'package:zachranobed/features/activepair/domain/repository/entity_pairs_repository.dart';
+import 'package:zachranobed/models/mapper/entity_pair_mapper.dart';
+import 'package:zachranobed/models/user_data.dart';
+import 'package:zachranobed/services/entity_pairs_service.dart';
+import 'package:zachranobed/services/entity_service.dart';
+
+/// Implementation of the [EntityPairsRepository] via Firebase services.
+class FirebaseEntityPairsRepository implements EntityPairsRepository {
+  final EntityService _entityService;
+  final EntityPairService _entityPairService;
+  final AppPreferences _appPreferences;
+
+  FirebaseEntityPairsRepository(
+    this._entityService,
+    this._entityPairService,
+    this._appPreferences,
+  );
+
+  @override
+  Future<void> changeActivePair({
+    required String donorId,
+    required String recipientId,
+  }) async {
+    _appPreferences.setActivePair(
+      EntityPairStruct(
+        donorId: donorId,
+        recipientId: recipientId,
+      ),
+    );
+  }
+
+  @override
+  Future<EntityPairsSummary> getEntityPairsSummary({
+    required UserData user,
+  }) async {
+    final pairs = await _entityPairService.getByUser(user);
+    if (pairs == null) {
+      throw Exception('Unable to retrieve entity pairs summary');
+    }
+
+    final entityPairs = await pairs.toDomain(
+      userEntityId: user.entityId,
+      entities: _entityService.fetchEntities,
+    );
+
+    final activePair = entityPairs.firstWhere(
+      (pair) =>
+          pair.donorId == user.activePair.donorId &&
+          pair.recipientId == user.activePair.recipientId,
+    );
+
+    return EntityPairsSummary(
+      active: activePair,
+      otherPairs: entityPairs
+          .whereNot(
+            (pair) =>
+                pair.donorId == activePair.donorId &&
+                pair.recipientId == activePair.recipientId,
+          )
+          .toList(),
+    );
+  }
+}

--- a/lib/features/activepair/di/active_pair_dependency_container.dart
+++ b/lib/features/activepair/di/active_pair_dependency_container.dart
@@ -1,0 +1,37 @@
+import 'package:get_it/get_it.dart';
+import 'package:zachranobed/common/prefs/app_preferences.dart';
+import 'package:zachranobed/features/activepair/data/repository/firebase_entity_pairs_repository.dart';
+import 'package:zachranobed/features/activepair/domain/repository/entity_pairs_repository.dart';
+import 'package:zachranobed/features/activepair/domain/usecase/change_active_pair_use_case.dart';
+import 'package:zachranobed/features/activepair/domain/usecase/get_entity_pairs_summary_use_case.dart';
+import 'package:zachranobed/services/entity_pairs_service.dart';
+import 'package:zachranobed/services/entity_service.dart';
+
+/// A dependency container for active pair related classes.
+class ActivePairDependencyContainer {
+  /// Private constructor to prevent instantiation.
+  const ActivePairDependencyContainer._();
+
+  /// Sets up the dependencies for the active pair feature.
+  static void setup() {
+    GetIt.I.registerFactory<EntityPairsRepository>(
+      () => FirebaseEntityPairsRepository(
+        GetIt.I<EntityService>(),
+        GetIt.I<EntityPairService>(),
+        GetIt.I<AppPreferences>(),
+      ),
+    );
+
+    GetIt.I.registerFactory<ChangeActivePairUseCase>(
+      () => ChangeActivePairUseCase(
+        GetIt.I<EntityPairsRepository>(),
+      ),
+    );
+
+    GetIt.I.registerFactory<GetEntityPairsSummaryUseCase>(
+      () => GetEntityPairsSummaryUseCase(
+        GetIt.I<EntityPairsRepository>(),
+      ),
+    );
+  }
+}

--- a/lib/features/activepair/domain/model/entity_pairs_summary.dart
+++ b/lib/features/activepair/domain/model/entity_pairs_summary.dart
@@ -1,0 +1,24 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:zachranobed/models/entity_pair.dart';
+
+/*
+ * Command to rebuild the entity_pairs_summary.freezed.dart file:
+ * flutter packages pub run build_runner build --delete-conflicting-outputs
+ */
+part 'entity_pairs_summary.freezed.dart';
+
+/// A summary of entity pairs.
+///
+/// This class holds information about the currently active pair and other
+/// available pairs.
+@Freezed()
+class EntityPairsSummary with _$EntityPairsSummary {
+  /// Creates a new [EntityPairsSummary] instance.
+  const factory EntityPairsSummary({
+    /// The currently active pair.
+    required EntityPair active,
+
+    /// A list of other available pairs.
+    required List<EntityPair> otherPairs,
+  }) = $EntityPairsSummary;
+}

--- a/lib/features/activepair/domain/model/entity_pairs_summary.freezed.dart
+++ b/lib/features/activepair/domain/model/entity_pairs_summary.freezed.dart
@@ -1,0 +1,172 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'entity_pairs_summary.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$EntityPairsSummary {
+  /// The currently active pair.
+  EntityPair get active => throw _privateConstructorUsedError;
+
+  /// A list of other available pairs.
+  List<EntityPair> get otherPairs => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $EntityPairsSummaryCopyWith<EntityPairsSummary> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $EntityPairsSummaryCopyWith<$Res> {
+  factory $EntityPairsSummaryCopyWith(
+          EntityPairsSummary value, $Res Function(EntityPairsSummary) then) =
+      _$EntityPairsSummaryCopyWithImpl<$Res, EntityPairsSummary>;
+  @useResult
+  $Res call({EntityPair active, List<EntityPair> otherPairs});
+}
+
+/// @nodoc
+class _$EntityPairsSummaryCopyWithImpl<$Res, $Val extends EntityPairsSummary>
+    implements $EntityPairsSummaryCopyWith<$Res> {
+  _$EntityPairsSummaryCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? active = null,
+    Object? otherPairs = null,
+  }) {
+    return _then(_value.copyWith(
+      active: null == active
+          ? _value.active
+          : active // ignore: cast_nullable_to_non_nullable
+              as EntityPair,
+      otherPairs: null == otherPairs
+          ? _value.otherPairs
+          : otherPairs // ignore: cast_nullable_to_non_nullable
+              as List<EntityPair>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$$EntityPairsSummaryImplCopyWith<$Res>
+    implements $EntityPairsSummaryCopyWith<$Res> {
+  factory _$$$EntityPairsSummaryImplCopyWith(_$$EntityPairsSummaryImpl value,
+          $Res Function(_$$EntityPairsSummaryImpl) then) =
+      __$$$EntityPairsSummaryImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({EntityPair active, List<EntityPair> otherPairs});
+}
+
+/// @nodoc
+class __$$$EntityPairsSummaryImplCopyWithImpl<$Res>
+    extends _$EntityPairsSummaryCopyWithImpl<$Res, _$$EntityPairsSummaryImpl>
+    implements _$$$EntityPairsSummaryImplCopyWith<$Res> {
+  __$$$EntityPairsSummaryImplCopyWithImpl(_$$EntityPairsSummaryImpl _value,
+      $Res Function(_$$EntityPairsSummaryImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? active = null,
+    Object? otherPairs = null,
+  }) {
+    return _then(_$$EntityPairsSummaryImpl(
+      active: null == active
+          ? _value.active
+          : active // ignore: cast_nullable_to_non_nullable
+              as EntityPair,
+      otherPairs: null == otherPairs
+          ? _value._otherPairs
+          : otherPairs // ignore: cast_nullable_to_non_nullable
+              as List<EntityPair>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$$EntityPairsSummaryImpl implements $EntityPairsSummary {
+  const _$$EntityPairsSummaryImpl(
+      {required this.active, required final List<EntityPair> otherPairs})
+      : _otherPairs = otherPairs;
+
+  /// The currently active pair.
+  @override
+  final EntityPair active;
+
+  /// A list of other available pairs.
+  final List<EntityPair> _otherPairs;
+
+  /// A list of other available pairs.
+  @override
+  List<EntityPair> get otherPairs {
+    if (_otherPairs is EqualUnmodifiableListView) return _otherPairs;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_otherPairs);
+  }
+
+  @override
+  String toString() {
+    return 'EntityPairsSummary(active: $active, otherPairs: $otherPairs)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$$EntityPairsSummaryImpl &&
+            (identical(other.active, active) || other.active == active) &&
+            const DeepCollectionEquality()
+                .equals(other._otherPairs, _otherPairs));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, active, const DeepCollectionEquality().hash(_otherPairs));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$$EntityPairsSummaryImplCopyWith<_$$EntityPairsSummaryImpl> get copyWith =>
+      __$$$EntityPairsSummaryImplCopyWithImpl<_$$EntityPairsSummaryImpl>(
+          this, _$identity);
+}
+
+abstract class $EntityPairsSummary implements EntityPairsSummary {
+  const factory $EntityPairsSummary(
+      {required final EntityPair active,
+      required final List<EntityPair> otherPairs}) = _$$EntityPairsSummaryImpl;
+
+  @override
+
+  /// The currently active pair.
+  EntityPair get active;
+  @override
+
+  /// A list of other available pairs.
+  List<EntityPair> get otherPairs;
+  @override
+  @JsonKey(ignore: true)
+  _$$$EntityPairsSummaryImplCopyWith<_$$EntityPairsSummaryImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/activepair/domain/repository/entity_pairs_repository.dart
+++ b/lib/features/activepair/domain/repository/entity_pairs_repository.dart
@@ -1,0 +1,16 @@
+import 'package:zachranobed/features/activepair/domain/model/entity_pairs_summary.dart';
+import 'package:zachranobed/models/user_data.dart';
+
+/// Repository to manage entity pairs information.
+abstract class EntityPairsRepository {
+  /// Changes the active pair.
+  Future<void> changeActivePair({
+    required String donorId,
+    required String recipientId,
+  });
+
+  /// Fetches available pairs summary information for the [user].
+  Future<EntityPairsSummary> getEntityPairsSummary({
+    required UserData user,
+  });
+}

--- a/lib/features/activepair/domain/usecase/change_active_pair_use_case.dart
+++ b/lib/features/activepair/domain/usecase/change_active_pair_use_case.dart
@@ -1,0 +1,16 @@
+import 'package:zachranobed/features/activepair/domain/repository/entity_pairs_repository.dart';
+
+/// A use case for changing the active pair.
+class ChangeActivePairUseCase {
+  final EntityPairsRepository _repository;
+
+  ChangeActivePairUseCase(this._repository);
+
+  /// Changes the active pair.
+  Future<void> invoke(String donorId, String recipientId) {
+    return _repository.changeActivePair(
+      donorId: donorId,
+      recipientId: recipientId,
+    );
+  }
+}

--- a/lib/features/activepair/domain/usecase/get_entity_pairs_summary_use_case.dart
+++ b/lib/features/activepair/domain/usecase/get_entity_pairs_summary_use_case.dart
@@ -1,0 +1,15 @@
+import 'package:zachranobed/features/activepair/domain/model/entity_pairs_summary.dart';
+import 'package:zachranobed/features/activepair/domain/repository/entity_pairs_repository.dart';
+import 'package:zachranobed/models/user_data.dart';
+
+/// A use case for retrieving entity pairs summary information.
+class GetEntityPairsSummaryUseCase {
+  final EntityPairsRepository _repository;
+
+  GetEntityPairsSummaryUseCase(this._repository);
+
+  /// Fetches available pairs summary information for the [user].
+  Future<EntityPairsSummary> invoke(UserData user) {
+    return _repository.getEntityPairsSummary(user: user);
+  }
+}

--- a/lib/features/activepair/presentation/change_active_pair_screen.dart
+++ b/lib/features/activepair/presentation/change_active_pair_screen.dart
@@ -1,0 +1,126 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:zachranobed/common/constants.dart';
+import 'package:zachranobed/common/helper_service.dart';
+import 'package:zachranobed/extensions/build_context_extensions.dart';
+import 'package:zachranobed/features/activepair/domain/model/entity_pairs_summary.dart';
+import 'package:zachranobed/features/activepair/domain/usecase/change_active_pair_use_case.dart';
+import 'package:zachranobed/features/activepair/domain/usecase/get_entity_pairs_summary_use_case.dart';
+import 'package:zachranobed/models/charity.dart';
+import 'package:zachranobed/ui/widgets/button.dart';
+import 'package:zachranobed/ui/widgets/card_row.dart';
+import 'package:zachranobed/ui/widgets/error_content.dart';
+
+/// A screen that displays a list of available pairs and allows to change it.
+///
+/// Note: It should be shown only for [Charity] user, but with a few text
+/// changes it may be used also for [Canteen].
+@RoutePage()
+class ChangeActivePairScreen extends StatefulWidget {
+  /// Creates a [ChangeActivePairScreen].
+  const ChangeActivePairScreen({super.key});
+
+  @override
+  State<ChangeActivePairScreen> createState() =>
+      _ChangeActiveCanteenScreenState();
+}
+
+class _ChangeActiveCanteenScreenState extends State<ChangeActivePairScreen> {
+  final _getEntityPairsSummary = GetIt.I<GetEntityPairsSummaryUseCase>();
+  final _changeActivePair = GetIt.I<ChangeActivePairUseCase>();
+
+  late Future<EntityPairsSummary> _entityPairsSummaryFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSummary();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(context.l10n!.activePairCanteenTitle),
+        automaticallyImplyLeading: false,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.close),
+            onPressed: () => Navigator.pop(context),
+          ),
+        ],
+      ),
+      body: FutureBuilder(
+        future: _entityPairsSummaryFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return _loading();
+          } else if (snapshot.hasError || snapshot.data == null) {
+            return _error(context);
+          }
+          return _entityPairs(snapshot.data!);
+        },
+      ),
+    );
+  }
+
+  /// Loads entity pairs summary.
+  void _loadSummary() {
+    setState(() {
+      final user = HelperService.getCurrentUser(context)!;
+      _entityPairsSummaryFuture = _getEntityPairsSummary.invoke(user);
+    });
+  }
+
+  /// Builds the entity pairs content for the given [summary].
+  Widget _entityPairs(EntityPairsSummary summary) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(WidgetStyle.padding),
+        child: Column(
+          children: [
+            CardRow(
+              label: context.l10n!.activePairCardCanteenLabel,
+              title: summary.active.donorEstablishmentName,
+            ),
+            const SizedBox(height: GapSize.xs),
+            ...summary.otherPairs.map((pair) {
+              return CardRow(
+                title: pair.donorEstablishmentName,
+                action: (context) {
+                  return ZOButton(
+                    text: context.l10n!.activePairCardSelectAction,
+                    type: ZOButtonType.secondary,
+                    height: 40.0,
+                    fullWidth: false,
+                    onPressed: () {
+                      _changeActivePair.invoke(pair.donorId, pair.recipientId);
+                      HelperService.updateActivePair(context, pair);
+                      Navigator.pop(context);
+                    },
+                  );
+                },
+              );
+            }),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Builds a loading screen.
+  Widget _loading() {
+    return const Expanded(child: Center(child: CircularProgressIndicator()));
+  }
+
+  /// Builds a generic error screen.
+  Widget _error(BuildContext context) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(WidgetStyle.padding),
+        child: ErrorContent(onRetryPressed: _loadSummary),
+      ),
+    );
+  }
+}

--- a/lib/features/activepair/presentation/change_active_pair_screen.dart
+++ b/lib/features/activepair/presentation/change_active_pair_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:zachranobed/common/constants.dart';
 import 'package:zachranobed/common/helper_service.dart';
+import 'package:zachranobed/common/utils/iterable_utils.dart';
 import 'package:zachranobed/extensions/build_context_extensions.dart';
 import 'package:zachranobed/features/activepair/domain/model/entity_pairs_summary.dart';
 import 'package:zachranobed/features/activepair/domain/usecase/change_active_pair_use_case.dart';
@@ -84,7 +85,7 @@ class _ChangeActiveCanteenScreenState extends State<ChangeActivePairScreen> {
               label: context.l10n!.activePairCardCanteenLabel,
               title: summary.active.donorEstablishmentName,
             ),
-            const SizedBox(height: GapSize.xs),
+            const SizedBox(height: 8.0),
             ...summary.otherPairs.map((pair) {
               return CardRow(
                 title: pair.donorEstablishmentName,
@@ -102,7 +103,7 @@ class _ChangeActiveCanteenScreenState extends State<ChangeActivePairScreen> {
                   );
                 },
               );
-            }),
+            }).separated(const SizedBox(height: 8.0)),
           ],
         ),
       ),

--- a/lib/features/foodboxes/data/repository/firebase_food_box_repository.dart
+++ b/lib/features/foodboxes/data/repository/firebase_food_box_repository.dart
@@ -11,6 +11,7 @@ import 'package:zachranobed/models/dto/delivery_dto.dart';
 import 'package:zachranobed/models/dto/food_box_delivery_dto.dart';
 import 'package:zachranobed/models/dto/food_box_pair_dto.dart';
 import 'package:zachranobed/models/dto/food_box_type_dto.dart';
+import 'package:zachranobed/models/user_data.dart';
 import 'package:zachranobed/services/delivery_service.dart';
 import 'package:zachranobed/services/entity_pairs_service.dart';
 import 'package:zachranobed/services/food_box_service.dart';
@@ -38,28 +39,29 @@ class FirebaseFoodBoxRepository implements FoodBoxRepository {
   }
 
   @override
-  Stream<Iterable<FoodBoxStatistics>> observeStatistics(
-      String entityId) async* {
+  Stream<Iterable<FoodBoxStatistics>> observeStatistics(UserData user) async* {
     // Prefetch types once before stream is started to not fetch them with
     // every change in the stream.
     final typesList = await getTypes();
     final typesMap = {for (final v in typesList) v.id: v};
+    final pairStream = _entityPairService.observePair(
+      donorId: user.activePair.donorId,
+      recipientId: user.activePair.recipientId,
+    );
 
-    yield* _entityPairService.observePairs(entityId).map((pairs) {
+    yield* pairStream.map((pair) {
       // Create accumulator map, as multiple pairs may have same food box types
       // and we would like to show aggregated statistics across all pairs.
       final Map<String, FoodBoxPairDto> boxesCountMap = {};
 
-      for (final pair in pairs) {
-        for (final foodBox in pair.foodboxes) {
-          final acc = boxesCountMap[foodBox.foodBoxId];
-          boxesCountMap[foodBox.foodBoxId] = FoodBoxPairDto(
-            foodBoxId: foodBox.foodBoxId,
-            count: (acc?.count ?? 0) + foodBox.count,
-            donorCount: (acc?.donorCount ?? 0) + foodBox.donorCount,
-            recipientCount: (acc?.recipientCount ?? 0) + foodBox.recipientCount,
-          );
-        }
+      for (final foodBox in pair?.foodboxes ?? <FoodBoxPairDto>[]) {
+        final acc = boxesCountMap[foodBox.foodBoxId];
+        boxesCountMap[foodBox.foodBoxId] = FoodBoxPairDto(
+          foodBoxId: foodBox.foodBoxId,
+          count: (acc?.count ?? 0) + foodBox.count,
+          donorCount: (acc?.donorCount ?? 0) + foodBox.donorCount,
+          recipientCount: (acc?.recipientCount ?? 0) + foodBox.recipientCount,
+        );
       }
 
       // Map accumulated values to domain instances
@@ -83,7 +85,7 @@ class FirebaseFoodBoxRepository implements FoodBoxRepository {
 
   @override
   Stream<Iterable<BoxMovement>> observeHistory({
-    required String entityId,
+    required UserData user,
     required DateTime from,
     required DateTime to,
   }) async* {
@@ -91,10 +93,14 @@ class FirebaseFoodBoxRepository implements FoodBoxRepository {
     // every change in the stream.
     final typesList = await getTypes();
     final typesMap = {for (final v in typesList) v.id: v};
+    final deliveries = _deliveryService.observeDeliveries(
+      donorId: user.activePair.donorId,
+      recipientId: user.activePair.recipientId,
+      from: from,
+      to: to,
+    );
 
-    yield* _deliveryService
-        .observeDeliveries(entityId, null, from, to)
-        .map((deliveries) {
+    yield* deliveries.map((deliveries) {
       final foodLists = deliveries.map((delivery) {
         // Map food-boxes with types to the BoxMovement
         return delivery.foodBoxes.mapNotNull((element) {
@@ -105,7 +111,7 @@ class FirebaseFoodBoxRepository implements FoodBoxRepository {
           return element.toDomain(
             delivery: delivery,
             type: type,
-            isNegative: _shouldUseNegativeBoxCount(entityId, delivery),
+            isNegative: _shouldUseNegativeBoxCount(user.entityId, delivery),
           );
         });
       });
@@ -116,11 +122,11 @@ class FirebaseFoodBoxRepository implements FoodBoxRepository {
 
   @override
   Future<bool> verifyAvailableBoxCount({
-    required String entityId,
+    required UserData user,
     required Map<String, int> requiredBoxes,
     required int Function(FoodBoxStatistics) getQuantity,
   }) async {
-    final statistics = await observeStatistics(entityId).first;
+    final statistics = await observeStatistics(user).first;
     final statisticsMap = {for (final s in statistics) s.type.id: s};
 
     for (final item in requiredBoxes.entries) {
@@ -142,9 +148,7 @@ class FirebaseFoodBoxRepository implements FoodBoxRepository {
 
   @override
   Future<bool> createBoxDelivery({
-    required String entityId,
-    required String donorId,
-    required String carrierId,
+    required UserData user,
     required List<BoxInfo> boxInfo,
   }) async {
     final Map<String, int> foodBoxesCount = {};
@@ -157,9 +161,11 @@ class FirebaseFoodBoxRepository implements FoodBoxRepository {
       foodBoxesCount[foodBoxId] = (foodBoxesCount[foodBoxId] ?? 0) + required;
     }
 
+    final donorId = user.activePair.donorId;
+    final recipientId = user.activePair.recipientId;
     final moveBoxesSuccess = await _entityPairService.moveBoxesToDonor(
       donorId: donorId,
-      recipientId: entityId,
+      recipientId: recipientId,
       changeMap: foodBoxesCount,
     );
 
@@ -168,7 +174,7 @@ class FirebaseFoodBoxRepository implements FoodBoxRepository {
     }
 
     // Prepare delivery ID and check if any exists in Firebase
-    final id = '$entityId-$donorId-${DateTimeUtils.getCurrentDayMark()}';
+    final id = '$recipientId-$donorId-${DateTimeUtils.getCurrentDayMark()}';
     final delivery = await _deliveryService.getDeliveryById(id);
     if (delivery != null) {
       // Add to count map existing boxes count
@@ -191,8 +197,8 @@ class FirebaseFoodBoxRepository implements FoodBoxRepository {
       final newDelivery = DeliveryDto(
         id: id,
         donorId: donorId,
-        recipientId: entityId,
-        carrierId: carrierId,
+        recipientId: recipientId,
+        carrierId: user.activePair.carrierId,
         deliveryDate: DateTime.now(),
         foodBoxes: foodBoxes.toList(),
         meals: [],
@@ -206,9 +212,12 @@ class FirebaseFoodBoxRepository implements FoodBoxRepository {
   }
 
   @override
-  Future<int> getMovementBoxesCount({required String entityId}) async {
+  Future<int> getMovementBoxesCount({required UserData user}) async {
     final deliveries = await _deliveryService
-        .observeDeliveries(entityId, null, null, null)
+        .observeDeliveries(
+          donorId: user.activePair.donorId,
+          recipientId: user.activePair.recipientId,
+        )
         .first;
 
     return deliveries.fold<int>(0, (totalCount, delivery) {

--- a/lib/features/foodboxes/domain/repository/food_box_repository.dart
+++ b/lib/features/foodboxes/domain/repository/food_box_repository.dart
@@ -2,6 +2,7 @@ import 'package:zachranobed/features/foodboxes/domain/model/box_info.dart';
 import 'package:zachranobed/features/foodboxes/domain/model/box_movement.dart';
 import 'package:zachranobed/features/foodboxes/domain/model/food_box_statistics.dart';
 import 'package:zachranobed/features/foodboxes/domain/model/food_box_type.dart';
+import 'package:zachranobed/models/user_data.dart';
 
 /// Repository to manage food boxes information
 abstract class FoodBoxRepository {
@@ -10,38 +11,33 @@ abstract class FoodBoxRepository {
   /// should be returned.
   Future<Iterable<FoodBoxType>> getTypes({bool includeDisposable = false});
 
-  /// Return a stream with a list of food box statistics for the user with
-  /// given [entityId].
-  Stream<Iterable<FoodBoxStatistics>> observeStatistics(String entityId);
+  /// Return a stream with a list of food box statistics for the [user].
+  Stream<Iterable<FoodBoxStatistics>> observeStatistics(UserData user);
 
-  /// Returns a stream with a list of box movements for the user with given
-  /// [entityId].
+  /// Returns a stream with a list of box movements for the [user].
   Stream<Iterable<BoxMovement>> observeHistory({
-    required String entityId,
+    required UserData user,
     required DateTime from,
     required DateTime to,
   });
 
-  /// Checks if entity with the given [entityId] has at least [requiredBoxes]
+  /// Checks if entity with the given [user] has at least [requiredBoxes]
   /// count. The [requiredBoxes] map contains keys with box IDs and values for
   /// count of required boxes. The [getQuantity] lambda is used to get correct
   /// quantity from [FoodBoxStatistics] instance for comparison.
   Future<bool> verifyAvailableBoxCount({
-    required String entityId,
+    required UserData user,
     required Map<String, int> requiredBoxes,
     required int Function(FoodBoxStatistics) getQuantity,
   });
 
-  /// Creates a box delivery from the given [entityId] to the [donorId] with
-  /// a given list of boxes using the [carrierId].
+  /// Creates a box delivery from the given [user] to it's active pair.
   Future<bool> createBoxDelivery({
-    required String entityId,
-    required String donorId,
-    required String carrierId,
+    required UserData user,
     required List<BoxInfo> boxInfo,
   });
 
   Future<int> getMovementBoxesCount({
-    required String entityId,
+    required UserData user,
   });
 }

--- a/lib/features/foodboxes/presentation/screen/boxes_screen.dart
+++ b/lib/features/foodboxes/presentation/screen/boxes_screen.dart
@@ -35,7 +35,7 @@ class _BoxesScreenState extends State<BoxesScreen> {
     super.initState();
     final repository = GetIt.I<FoodBoxRepository>();
     _boxMovementCountFuture = repository.getMovementBoxesCount(
-      entityId: HelperService.getCurrentUser(context)!.entityId,
+      user: HelperService.getCurrentUser(context)!,
     );
   }
 

--- a/lib/features/foodboxes/presentation/widget/box_data_table.dart
+++ b/lib/features/foodboxes/presentation/widget/box_data_table.dart
@@ -16,7 +16,7 @@ class BoxDataTable extends StatelessWidget {
     final repository = GetIt.I<FoodBoxRepository>();
 
     return StreamBuilder<Iterable<FoodBoxStatistics>>(
-      stream: repository.observeStatistics(user.entityId),
+      stream: repository.observeStatistics(user),
       builder: (context, snapshot) {
         if (snapshot.hasData) {
           final boxes = snapshot.data!;

--- a/lib/features/foodboxes/presentation/widget/box_movement_list.dart
+++ b/lib/features/foodboxes/presentation/widget/box_movement_list.dart
@@ -41,7 +41,7 @@ class BoxMovementList extends StatelessWidget {
         const SizedBox(height: GapSize.xs),
         StreamBuilder<Iterable<BoxMovement>>(
           stream: _repository.observeHistory(
-            entityId: HelperService.getCurrentUser(context)!.entityId,
+            user: HelperService.getCurrentUser(context)!,
             from: deliveredFrom,
             to: deliveredTo,
           ),

--- a/lib/features/menu/data/repository/firebase_contacts_repository.dart
+++ b/lib/features/menu/data/repository/firebase_contacts_repository.dart
@@ -34,7 +34,7 @@ class FirebaseContactsRepository implements ContactsRepository {
     }
     return Future.wait(
       [
-        getEntityContacts(getTargetEntityIds(user.entityId, pairs)),
+        getEntityContacts(user, getTargetEntityIds(user.entityId, pairs)),
         getDeliveryContacts(pairs),
         getOrganisationContacts(),
       ],
@@ -60,9 +60,11 @@ class FirebaseContactsRepository implements ContactsRepository {
   /// Retrieves a list of [EntityContacts] of given entity IDs.
   /// The final list is sorted by establishment name.
   Future<List<EntityContacts>> getEntityContacts(
+    UserData user,
     List<String> entityIds,
   ) async {
     final entities = await _entityService.fetchEntities(entityIds);
+    final activePair = user.activePair;
     return entities.map((e) {
       final mainContact = Contact(
         name: e.responsiblePerson,
@@ -73,6 +75,7 @@ class FirebaseContactsRepository implements ContactsRepository {
 
       return EntityContacts(
         name: e.establishmentName,
+        active: e.id == activePair.donorId || e.id == activePair.recipientId,
         contacts: [mainContact, ...contacts],
       );
     }).sortedBy((e) => e.name);

--- a/lib/features/menu/data/repository/firebase_contacts_repository.dart
+++ b/lib/features/menu/data/repository/firebase_contacts_repository.dart
@@ -6,6 +6,7 @@ import 'package:zachranobed/features/menu/domain/model/contacts_summary.dart';
 import 'package:zachranobed/features/menu/domain/model/entity_contacts.dart';
 import 'package:zachranobed/features/menu/domain/repository/contacts_repository.dart';
 import 'package:zachranobed/models/dto/entity_pair_dto.dart';
+import 'package:zachranobed/models/user_data.dart';
 import 'package:zachranobed/services/carrier_service.dart';
 import 'package:zachranobed/services/configuration_service.dart';
 import 'package:zachranobed/services/entity_pairs_service.dart';
@@ -26,11 +27,14 @@ class FirebaseContactsRepository implements ContactsRepository {
   );
 
   @override
-  Future<ContactsSummary> getContacts({required String entityId}) async {
-    final pairs = await getPairs(entityId);
+  Future<ContactsSummary> getContacts({required UserData user}) async {
+    final pairs = await _entityPairService.getByUser(user);
+    if (pairs == null) {
+      throw Exception('Unable to retrieve entity pairs summary');
+    }
     return Future.wait(
       [
-        getEntityContacts(getTargetEntityIds(entityId, pairs)),
+        getEntityContacts(getTargetEntityIds(user.entityId, pairs)),
         getDeliveryContacts(pairs),
         getOrganisationContacts(),
       ],
@@ -41,11 +45,6 @@ class FirebaseContactsRepository implements ContactsRepository {
         organisationContacts: values[2].cast(),
       );
     });
-  }
-
-  /// Retrieves a list of entity pairs for the given [entityId].
-  Future<List<EntityPairDto>> getPairs(String entityId) async {
-    return (await _entityPairService.observePairs(entityId).first).toList();
   }
 
   /// Retrieves a list of entity IDs that are paired with the given [entityId].

--- a/lib/features/menu/domain/model/entity_contacts.dart
+++ b/lib/features/menu/domain/model/entity_contacts.dart
@@ -11,6 +11,7 @@ part 'entity_contacts.freezed.dart';
 class EntityContacts with _$EntityContacts {
   const factory EntityContacts({
     required String name,
+    required bool active,
     required List<Contact> contacts,
   }) = $EntityContacts;
 }

--- a/lib/features/menu/domain/model/entity_contacts.freezed.dart
+++ b/lib/features/menu/domain/model/entity_contacts.freezed.dart
@@ -17,6 +17,7 @@ final _privateConstructorUsedError = UnsupportedError(
 /// @nodoc
 mixin _$EntityContacts {
   String get name => throw _privateConstructorUsedError;
+  bool get active => throw _privateConstructorUsedError;
   List<Contact> get contacts => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
@@ -30,7 +31,7 @@ abstract class $EntityContactsCopyWith<$Res> {
           EntityContacts value, $Res Function(EntityContacts) then) =
       _$EntityContactsCopyWithImpl<$Res, EntityContacts>;
   @useResult
-  $Res call({String name, List<Contact> contacts});
+  $Res call({String name, bool active, List<Contact> contacts});
 }
 
 /// @nodoc
@@ -47,6 +48,7 @@ class _$EntityContactsCopyWithImpl<$Res, $Val extends EntityContacts>
   @override
   $Res call({
     Object? name = null,
+    Object? active = null,
     Object? contacts = null,
   }) {
     return _then(_value.copyWith(
@@ -54,6 +56,10 @@ class _$EntityContactsCopyWithImpl<$Res, $Val extends EntityContacts>
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
+      active: null == active
+          ? _value.active
+          : active // ignore: cast_nullable_to_non_nullable
+              as bool,
       contacts: null == contacts
           ? _value.contacts
           : contacts // ignore: cast_nullable_to_non_nullable
@@ -70,7 +76,7 @@ abstract class _$$$EntityContactsImplCopyWith<$Res>
       __$$$EntityContactsImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({String name, List<Contact> contacts});
+  $Res call({String name, bool active, List<Contact> contacts});
 }
 
 /// @nodoc
@@ -85,6 +91,7 @@ class __$$$EntityContactsImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? name = null,
+    Object? active = null,
     Object? contacts = null,
   }) {
     return _then(_$$EntityContactsImpl(
@@ -92,6 +99,10 @@ class __$$$EntityContactsImplCopyWithImpl<$Res>
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
+      active: null == active
+          ? _value.active
+          : active // ignore: cast_nullable_to_non_nullable
+              as bool,
       contacts: null == contacts
           ? _value._contacts
           : contacts // ignore: cast_nullable_to_non_nullable
@@ -104,11 +115,15 @@ class __$$$EntityContactsImplCopyWithImpl<$Res>
 
 class _$$EntityContactsImpl implements $EntityContacts {
   const _$$EntityContactsImpl(
-      {required this.name, required final List<Contact> contacts})
+      {required this.name,
+      required this.active,
+      required final List<Contact> contacts})
       : _contacts = contacts;
 
   @override
   final String name;
+  @override
+  final bool active;
   final List<Contact> _contacts;
   @override
   List<Contact> get contacts {
@@ -119,7 +134,7 @@ class _$$EntityContactsImpl implements $EntityContacts {
 
   @override
   String toString() {
-    return 'EntityContacts(name: $name, contacts: $contacts)';
+    return 'EntityContacts(name: $name, active: $active, contacts: $contacts)';
   }
 
   @override
@@ -128,12 +143,13 @@ class _$$EntityContactsImpl implements $EntityContacts {
         (other.runtimeType == runtimeType &&
             other is _$$EntityContactsImpl &&
             (identical(other.name, name) || other.name == name) &&
+            (identical(other.active, active) || other.active == active) &&
             const DeepCollectionEquality().equals(other._contacts, _contacts));
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType, name, const DeepCollectionEquality().hash(_contacts));
+  int get hashCode => Object.hash(runtimeType, name, active,
+      const DeepCollectionEquality().hash(_contacts));
 
   @JsonKey(ignore: true)
   @override
@@ -146,10 +162,13 @@ class _$$EntityContactsImpl implements $EntityContacts {
 abstract class $EntityContacts implements EntityContacts {
   const factory $EntityContacts(
       {required final String name,
+      required final bool active,
       required final List<Contact> contacts}) = _$$EntityContactsImpl;
 
   @override
   String get name;
+  @override
+  bool get active;
   @override
   List<Contact> get contacts;
   @override

--- a/lib/features/menu/domain/repository/contacts_repository.dart
+++ b/lib/features/menu/domain/repository/contacts_repository.dart
@@ -1,7 +1,8 @@
 import 'package:zachranobed/features/menu/domain/model/contacts_summary.dart';
+import 'package:zachranobed/models/user_data.dart';
 
 /// Repository to fetch contacts information.
 abstract class ContactsRepository {
-  /// Fetches available contacts for the user with given [entityId].
-  Future<ContactsSummary> getContacts({required String entityId});
+  /// Fetches available contacts for the [user].
+  Future<ContactsSummary> getContacts({required UserData user});
 }

--- a/lib/features/menu/domain/usecase/get_contacts_use_case.dart
+++ b/lib/features/menu/domain/usecase/get_contacts_use_case.dart
@@ -1,5 +1,6 @@
 import 'package:zachranobed/features/menu/domain/model/contacts_summary.dart';
 import 'package:zachranobed/features/menu/domain/repository/contacts_repository.dart';
+import 'package:zachranobed/models/user_data.dart';
 
 /// A use case for retrieving contact information.
 class GetContactsUseCase {
@@ -7,8 +8,8 @@ class GetContactsUseCase {
 
   GetContactsUseCase(this._repository);
 
-  /// Fetches available contacts for the user with given [entityId].
-  Future<ContactsSummary> invoke(String entityId) {
-    return _repository.getContacts(entityId: entityId);
+  /// Fetches available contacts for the [user].
+  Future<ContactsSummary> invoke(UserData user) {
+    return _repository.getContacts(user: user);
   }
 }

--- a/lib/features/menu/presentation/contacts_screen.dart
+++ b/lib/features/menu/presentation/contacts_screen.dart
@@ -8,7 +8,9 @@ import 'package:zachranobed/common/utils/iterable_utils.dart';
 import 'package:zachranobed/extensions/build_context_extensions.dart';
 import 'package:zachranobed/features/menu/domain/model/contact.dart';
 import 'package:zachranobed/features/menu/domain/model/contacts_summary.dart';
+import 'package:zachranobed/features/menu/domain/model/entity_contacts.dart';
 import 'package:zachranobed/features/menu/domain/usecase/get_contacts_use_case.dart';
+import 'package:zachranobed/models/charity.dart';
 import 'package:zachranobed/ui/widgets/contact_row.dart';
 import 'package:zachranobed/ui/widgets/error_content.dart';
 import 'package:zachranobed/ui/widgets/menu/menu_section.dart';
@@ -102,6 +104,7 @@ class _ContactsScreenState extends State<ContactsScreen> {
           ...summary.targets.map((e) {
             return _menuSection(
               label: e.name,
+              labelSuffix: _resolveLabelSuffix(e),
               contacts: e.contacts,
               markFirstAsPreferred: e.contacts.length > 1,
             );
@@ -123,13 +126,14 @@ class _ContactsScreenState extends State<ContactsScreen> {
   Widget _menuSection({
     required String label,
     required List<Contact> contacts,
+    String labelSuffix = "",
     bool markFirstAsPreferred = false,
   }) {
     if (contacts.isEmpty) {
       return const SizedBox();
     }
     return MenuSection(
-      label: label,
+      label: (_) => _buildLabel(label, labelSuffix),
       menuItems: contacts
           .mapIndexed((index, e) {
             final contactName =
@@ -164,6 +168,37 @@ class _ContactsScreenState extends State<ContactsScreen> {
           ),
           const SizedBox(height: GapSize.xs),
         ],
+      ),
+    );
+  }
+
+  String _resolveLabelSuffix(EntityContacts contacts) {
+    final user = HelperService.getCurrentUser(context)!;
+
+    // Show "is active" suffix only for charity and an active pair
+    if (user is! Charity || !contacts.active) {
+      return "";
+    }
+
+    return context.l10n!.activePairContactsCanteenLabel;
+  }
+
+  Widget _buildLabel(String label, String labelSuffix) {
+    List<InlineSpan>? suffix;
+    if (labelSuffix.isNotEmpty) {
+      suffix = [
+        TextSpan(
+          text: " $labelSuffix",
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      ];
+    }
+
+    return Text.rich(
+      style: Theme.of(context).textTheme.titleMedium,
+      TextSpan(
+        text: label,
+        children: suffix,
       ),
     );
   }

--- a/lib/features/menu/presentation/contacts_screen.dart
+++ b/lib/features/menu/presentation/contacts_screen.dart
@@ -53,10 +53,10 @@ class _ContactsScreenState extends State<ContactsScreen> {
 
   /// Loads contacts summary.
   void _loadContacts() {
-    final entityId = HelperService.getCurrentUser(context)!.entityId;
     final getContacts = GetIt.I<GetContactsUseCase>();
     setState(() {
-      _contactsFuture = getContacts.invoke(entityId);
+      final user = HelperService.getCurrentUser(context)!;
+      _contactsFuture = getContacts.invoke(user);
     });
   }
 

--- a/lib/features/menu/presentation/menu_screen.dart
+++ b/lib/features/menu/presentation/menu_screen.dart
@@ -72,7 +72,7 @@ class _MenuScreenState extends State<MenuScreen> {
                 onPressed: () => context.router.push(const ContactsRoute()),
               ),
               const SizedBox(height: GapSize.m),
-              MenuSection(
+              MenuSection.simple(
                 label: context.l10n!.settings,
                 menuItems: [
                   MenuItem(
@@ -83,7 +83,7 @@ class _MenuScreenState extends State<MenuScreen> {
                   )
                 ],
               ),
-              MenuSection(
+              MenuSection.simple(
                 label: context.l10n!.saveLunch,
                 menuItems: [
                   MenuItem(
@@ -111,7 +111,7 @@ class _MenuScreenState extends State<MenuScreen> {
                   ),
                 ],
               ),
-              MenuSection(
+              MenuSection.simple(
                 label: context.l10n!.more,
                 menuItems: [
                   MenuItem(

--- a/lib/features/offeredfood/data/repository/firebase_offered_food_repository.dart
+++ b/lib/features/offeredfood/data/repository/firebase_offered_food_repository.dart
@@ -37,10 +37,13 @@ class FirebaseOfferedFoodRepository implements OfferedFoodRepository {
 
   @override
   Stream<Delivery?> observeCurrentDelivery({
-    required String entityId,
+    required UserData user,
   }) {
     return _deliveryService
-        .observeDelivery(entityId)
+        .observeDelivery(
+          donorId: user.activePair.donorId,
+          recipientId: user.activePair.recipientId,
+        )
         .map((event) => event?.toDomain());
   }
 

--- a/lib/features/offeredfood/data/repository/firebase_offered_food_repository.dart
+++ b/lib/features/offeredfood/data/repository/firebase_offered_food_repository.dart
@@ -9,6 +9,7 @@ import 'package:zachranobed/models/delivery.dart';
 import 'package:zachranobed/models/dto/delivery_dto.dart';
 import 'package:zachranobed/models/dto/meal_detail_dto.dart';
 import 'package:zachranobed/models/dto/meal_dto.dart';
+import 'package:zachranobed/models/user_data.dart';
 import 'package:zachranobed/services/delivery_service.dart';
 import 'package:zachranobed/services/entity_pairs_service.dart';
 import 'package:zachranobed/services/food_box_service.dart';
@@ -85,12 +86,15 @@ class FirebaseOfferedFoodRepository implements OfferedFoodRepository {
 
   @override
   Future<int> getSavedMealsCount({
-    required String entityId,
+    required UserData user,
     int? timePeriod,
   }) async {
     var mealsCount = 0;
-    final deliveries =
-        await _deliveryService.getDeliveries(entityId, timePeriod);
+    final deliveries = await _deliveryService.getDeliveries(
+      donorId: user.activePair.donorId,
+      recipientId: user.activePair.recipientId,
+      timePeriod: timePeriod,
+    );
     for (var delivery in deliveries) {
       mealsCount += delivery.meals.fold(0, (inc, e) => inc + e.count);
     }
@@ -99,17 +103,22 @@ class FirebaseOfferedFoodRepository implements OfferedFoodRepository {
 
   @override
   Stream<Iterable<OfferedFood>> observeHistory({
-    required String entityId,
+    required UserData user,
     int? limit,
     DateTime? from,
     DateTime? to,
   }) async* {
     final boxTypes = await _foodBoxService.getAll();
     final boxTypeMap = {for (final e in boxTypes) e.id: e.name};
+    final deliveries = _deliveryService.observeDeliveries(
+      donorId: user.activePair.donorId,
+      recipientId: user.activePair.recipientId,
+      limit: limit,
+      from: from,
+      to: to,
+    );
 
-    yield* _deliveryService
-        .observeDeliveries(entityId, limit, from, to)
-        .asyncMap((deliveries) async {
+    yield* deliveries.asyncMap((deliveries) async {
       final foodLists = await Future.wait(deliveries.map((delivery) async {
         // Get meal IDs and fetch meal details from MealService
         final mealIds = delivery.meals.map((e) => e.mealId);

--- a/lib/features/offeredfood/domain/model/food_info.dart
+++ b/lib/features/offeredfood/domain/model/food_info.dart
@@ -65,7 +65,7 @@ extension FoodInfoExtension on List<FoodInfo> {
     }
 
     final available = await foodBoxRepository.verifyAvailableBoxCount(
-      entityId: user.entityId,
+      user: user,
       requiredBoxes: requiredBoxes,
       getQuantity: (e) => e.quantityAtCanteen,
     );

--- a/lib/features/offeredfood/domain/model/food_info.freezed.dart
+++ b/lib/features/offeredfood/domain/model/food_info.freezed.dart
@@ -18,17 +18,11 @@ final _privateConstructorUsedError = UnsupportedError(
 mixin _$FoodInfo {
   String get id => throw _privateConstructorUsedError; // The UUID identifier
   String? get dishName => throw _privateConstructorUsedError;
-
   List<String>? get allergens => throw _privateConstructorUsedError;
-
   String? get foodCategory => throw _privateConstructorUsedError;
-
   int? get numberOfServings => throw _privateConstructorUsedError;
-
   int? get numberOfBoxes => throw _privateConstructorUsedError;
-
   String? get foodBoxId => throw _privateConstructorUsedError;
-
   DateTime? get consumeBy => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
@@ -40,7 +34,6 @@ mixin _$FoodInfo {
 abstract class $FoodInfoCopyWith<$Res> {
   factory $FoodInfoCopyWith(FoodInfo value, $Res Function(FoodInfo) then) =
       _$FoodInfoCopyWithImpl<$Res, FoodInfo>;
-
   @useResult
   $Res call(
       {String id,
@@ -60,7 +53,6 @@ class _$FoodInfoCopyWithImpl<$Res, $Val extends FoodInfo>
 
   // ignore: unused_field
   final $Val _value;
-
   // ignore: unused_field
   final $Res Function($Val) _then;
 
@@ -119,7 +111,6 @@ abstract class _$$FoodInfoImplCopyWith<$Res>
   factory _$$FoodInfoImplCopyWith(
           _$FoodInfoImpl value, $Res Function(_$FoodInfoImpl) then) =
       __$$FoodInfoImplCopyWithImpl<$Res>;
-
   @override
   @useResult
   $Res call(
@@ -206,12 +197,10 @@ class _$FoodInfoImpl implements _FoodInfo {
 
   @override
   final String id;
-
 // The UUID identifier
   @override
   final String? dishName;
   final List<String>? _allergens;
-
   @override
   List<String>? get allergens {
     final value = _allergens;
@@ -291,28 +280,20 @@ abstract class _FoodInfo implements FoodInfo {
 
   @override
   String get id;
-
-  @override
+  @override // The UUID identifier
   String? get dishName;
-
   @override
   List<String>? get allergens;
-
   @override
   String? get foodCategory;
-
   @override
   int? get numberOfServings;
-
   @override
   int? get numberOfBoxes;
-
   @override
   String? get foodBoxId;
-
   @override
   DateTime? get consumeBy;
-
   @override
   @JsonKey(ignore: true)
   _$$FoodInfoImplCopyWith<_$FoodInfoImpl> get copyWith =>

--- a/lib/features/offeredfood/domain/repository/offered_food_repository.dart
+++ b/lib/features/offeredfood/domain/repository/offered_food_repository.dart
@@ -1,6 +1,7 @@
 import 'package:zachranobed/features/offeredfood/domain/model/food_info.dart';
 import 'package:zachranobed/features/offeredfood/domain/model/offered_food.dart';
 import 'package:zachranobed/models/delivery.dart';
+import 'package:zachranobed/models/user_data.dart';
 
 /// Repository to manage offered food.
 abstract class OfferedFoodRepository {
@@ -29,17 +30,15 @@ abstract class OfferedFoodRepository {
   Future<bool> cancelDelivery({required Delivery delivery});
 
   /// Returns a [Future] that completes with an [int] representing the total
-  /// count of saved meals for the specified [timePeriod] and user with given
-  /// [entityId].
+  /// count of saved meals for the specified [timePeriod] and [user].
   Future<int> getSavedMealsCount({
-    required String entityId,
+    required UserData user,
     int? timePeriod,
   });
 
-  /// Returns a stream with a list of offered food for the user with given
-  /// [entityId].
+  /// Returns a stream with a list of offered food for the [user].
   Stream<Iterable<OfferedFood>> observeHistory({
-    required String entityId,
+    required UserData user,
     int? limit,
     DateTime? from,
     DateTime? to,

--- a/lib/features/offeredfood/domain/repository/offered_food_repository.dart
+++ b/lib/features/offeredfood/domain/repository/offered_food_repository.dart
@@ -5,12 +5,9 @@ import 'package:zachranobed/models/user_data.dart';
 
 /// Repository to manage offered food.
 abstract class OfferedFoodRepository {
-  /// Observes the current delivery for a specific entity.
-  ///
-  /// The [entityId] parameter is the ID of the entity whose delivery is to be
-  /// observed.
+  /// Observes the current delivery for a given [user].
   Stream<Delivery?> observeCurrentDelivery({
-    required String entityId,
+    required UserData user,
   });
 
   /// Checks if canteen could donate to the given [delivery]. The [time]

--- a/lib/features/offeredfood/presentation/screens/donations_screen.dart
+++ b/lib/features/offeredfood/presentation/screens/donations_screen.dart
@@ -32,7 +32,7 @@ class _DonationsScreenState extends State<DonationsScreen> {
     super.initState();
     final repository = GetIt.I<OfferedFoodRepository>();
     _mealsCountFuture = repository.getSavedMealsCount(
-      entityId: HelperService.getCurrentUser(context)!.entityId,
+      user: HelperService.getCurrentUser(context)!,
       timePeriod: null,
     );
   }

--- a/lib/features/offeredfood/presentation/widget/card_list.dart
+++ b/lib/features/offeredfood/presentation/widget/card_list.dart
@@ -23,7 +23,7 @@ class CardList extends StatelessWidget {
             Expanded(
               child: ZOCard(
                 measuredValue:
-                    repository.getSavedMealsCount(entityId: user.entityId),
+                    repository.getSavedMealsCount(user: user),
                 metricsText: context.l10n!.savedLunches,
                 periodText: context.l10n!.total,
               ),
@@ -32,7 +32,7 @@ class CardList extends StatelessWidget {
             Expanded(
               child: ZOCard(
                 measuredValue: repository.getSavedMealsCount(
-                  entityId: user.entityId,
+                  user: user,
                   timePeriod: 30,
                 ),
                 metricsText: context.l10n!.savedLunches,

--- a/lib/features/offeredfood/presentation/widget/donated_food_list.dart
+++ b/lib/features/offeredfood/presentation/widget/donated_food_list.dart
@@ -28,7 +28,7 @@ class DonatedFoodList extends StatelessWidget {
   Widget build(BuildContext context) {
     return StreamBuilder<Iterable<OfferedFood>>(
       stream: _repository.observeHistory(
-        entityId: HelperService.getCurrentUser(context)!.entityId,
+        user: HelperService.getCurrentUser(context)!,
         limit: itemsLimit,
         from: deliveredFrom,
         to: deliveredTo,

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -128,5 +128,6 @@
     "activePairCardCanteenLabel": "Aktivní jídelna",
     "activePairCardChangeAction": "Změnit",
     "activePairCardSelectAction": "Vybrat",
-    "activePairCanteenTitle": "Jídelna"
+    "activePairCanteenTitle": "Jídelna",
+    "activePairContactsCanteenLabel": "(aktivní jídelna)"
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -124,5 +124,9 @@
     "offerFoodOverviewScreenTitle": "Shrnutí",
     "offerFoodOverviewBanner": "Zkontrolujte si prosím počet krabiček a porcí.",
     "offerFoodDetailScreenTitle": "Úprava zadaného pokrmu",
-    "offerFoodDetailSaveButton": "Uložit změny"
+    "offerFoodDetailSaveButton": "Uložit změny",
+    "activePairCardCanteenLabel": "Aktivní jídelna",
+    "activePairCardChangeAction": "Změnit",
+    "activePairCardSelectAction": "Vybrat",
+    "activePairCanteenTitle": "Jídelna"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:intl/date_symbol_data_local.dart';
 import 'package:zachranobed/common/di/common_dependency_container.dart';
 import 'package:zachranobed/common/logger/zo_logger.dart';
 import 'package:zachranobed/common/firebase/firebase_helper.dart';
+import 'package:zachranobed/features/activepair/di/active_pair_dependency_container.dart';
 import 'package:zachranobed/features/appConfiguration/app_configuration.dart';
 import 'package:zachranobed/features/appConfiguration/mapper/app_configuration_mapper.dart';
 import 'package:zachranobed/features/appTerms/di/app_terms_dependency_container.dart';
@@ -34,6 +35,7 @@ void main() async {
   FoodBoxDependencyContainer.setup();
   OfferedFoodDependencyContainer.setup();
   MenuDependencyContainer.setup();
+  ActivePairDependencyContainer.setup();
 
   ZOLogger.init();
 

--- a/lib/models/canteen.dart
+++ b/lib/models/canteen.dart
@@ -1,12 +1,9 @@
+import 'package:zachranobed/common/utils/date_time_utils.dart';
 import 'package:zachranobed/models/user_data.dart';
 
-import '../common/utils/date_time_utils.dart';
+import 'entity_pair.dart';
 
 class Canteen extends UserData {
-  final String pickUpFrom;
-  final String pickUpWithin;
-  final String recipientId;
-
   Canteen({
     required super.entityId,
     required super.email,
@@ -14,9 +11,8 @@ class Canteen extends UserData {
     required super.establishmentId,
     required super.organization,
     required super.lastAcceptedAppTermsVersion,
-    required this.pickUpFrom,
-    required this.pickUpWithin,
-    required this.recipientId,
+    required super.activePair,
+    required super.hasMultiplePairs,
   });
 
   /// Checks if the current time is within the pickup range for a [Canteen].
@@ -30,5 +26,23 @@ class Canteen extends UserData {
     DateTime timeWithin =
         DateTimeUtils.getDateTimeOfCurrentDelivery(pickUpWithin);
     return now.isBefore(timeWithin);
+  }
+
+  String get pickUpFrom => activePair.pickupTimeStart;
+
+  String get pickUpWithin => activePair.pickupTimeEnd;
+
+  @override
+  UserData copyWith({required EntityPair activePair}) {
+    return Canteen(
+      entityId: entityId,
+      email: email,
+      establishmentName: establishmentName,
+      establishmentId: establishmentId,
+      organization: organization,
+      lastAcceptedAppTermsVersion: lastAcceptedAppTermsVersion,
+      hasMultiplePairs: hasMultiplePairs,
+      activePair: activePair,
+    );
   }
 }

--- a/lib/models/charity.dart
+++ b/lib/models/charity.dart
@@ -1,9 +1,7 @@
+import 'package:zachranobed/models/entity_pair.dart';
 import 'package:zachranobed/models/user_data.dart';
 
 class Charity extends UserData {
-  final List<String> donorIds;
-  final List<String> carrierIds;
-
   Charity({
     required super.entityId,
     required super.email,
@@ -11,7 +9,21 @@ class Charity extends UserData {
     required super.establishmentId,
     required super.organization,
     required super.lastAcceptedAppTermsVersion,
-    required this.donorIds,
-    required this.carrierIds,
+    required super.activePair,
+    required super.hasMultiplePairs,
   });
+
+  @override
+  UserData copyWith({required EntityPair activePair}) {
+    return Charity(
+      entityId: entityId,
+      email: email,
+      establishmentName: establishmentName,
+      establishmentId: establishmentId,
+      organization: organization,
+      lastAcceptedAppTermsVersion: lastAcceptedAppTermsVersion,
+      hasMultiplePairs: hasMultiplePairs,
+      activePair: activePair,
+    );
+  }
 }

--- a/lib/models/entity_pair.dart
+++ b/lib/models/entity_pair.dart
@@ -1,0 +1,34 @@
+/// Represents an entity pair between donor and recipient (canteen and charity).
+class EntityPair {
+  /// The entity ID of the donor entity.
+  final String donorId;
+
+  /// The name of the donor establishment.
+  final String donorEstablishmentName;
+
+  /// The entity ID of the recipient entity.
+  final String recipientId;
+
+  /// The name of the recipient establishment.
+  final String recipientEstablishmentName;
+
+  /// The carrier ID used for delivery.
+  final String carrierId;
+
+  /// The time (HH:mm) when pickup window starts.
+  final String pickupTimeStart;
+
+  /// The time (HH:mm) when pickup window ends.
+  final String pickupTimeEnd;
+
+  /// Creates a new [EntityPair] instance.
+  EntityPair({
+    required this.donorId,
+    required this.donorEstablishmentName,
+    required this.recipientId,
+    required this.recipientEstablishmentName,
+    required this.carrierId,
+    required this.pickupTimeStart,
+    required this.pickupTimeEnd,
+  });
+}

--- a/lib/models/mapper/entity_pair_mapper.dart
+++ b/lib/models/mapper/entity_pair_mapper.dart
@@ -1,0 +1,76 @@
+import 'package:collection/collection.dart';
+import 'package:zachranobed/common/utils/iterable_utils.dart';
+import 'package:zachranobed/models/dto/entity_dto.dart';
+import 'package:zachranobed/models/dto/entity_pair_dto.dart';
+import 'package:zachranobed/models/entity_pair.dart';
+
+/// DTO to domain mapper for [EntityPair].
+extension EntityPairMapper on EntityPairDto {
+  /// Maps DTO to domain representation.
+  EntityPair? toDomain({
+    EntityDto? donor,
+    EntityDto? recipient,
+  }) {
+    if (donor == null || recipient == null) {
+      return null;
+    }
+
+    final window = pickupTimeWindows.firstOrNull;
+    if (window == null) {
+      return null;
+    }
+
+    return EntityPair(
+      donorId: donor.id,
+      donorEstablishmentName: donor.establishmentName,
+      recipientId: recipient.id,
+      recipientEstablishmentName: recipient.establishmentName,
+      carrierId: carrierId,
+      pickupTimeStart: window.start,
+      pickupTimeEnd: window.end,
+    );
+  }
+}
+
+/// DTO to domain mapper for list of [EntityPair].
+extension EntityPairListMapper on List<EntityPairDto> {
+  /// Maps DTO to domain representation.
+  ///
+  /// This method retrieves the entity details for the donor and recipient of
+  /// each pair using the provided [entities] function. The resulting list is
+  /// sorted based on the establishment name of the other entity in the pair
+  /// (recipient for donor, donor for recipient).
+  Future<List<EntityPair>> toDomain({
+    required String userEntityId,
+    required Future<List<EntityDto>> Function(List<String> ids) entities,
+  }) async {
+    final targetIds = mapNotNull((e) {
+      if (userEntityId == e.donorId) {
+        return e.recipientId;
+      }
+      if (userEntityId == e.recipientId) {
+        return e.donorId;
+      }
+      return null;
+    });
+
+    final entitiesList = await entities([userEntityId, ...targetIds]);
+    final entitiesMap = {for (final e in entitiesList) e.id: e};
+    final pairs = mapNotNull(
+      (pair) => pair.toDomain(
+        donor: entitiesMap[pair.donorId],
+        recipient: entitiesMap[pair.recipientId],
+      ),
+    );
+
+    return pairs.toList().sortedBy((e) {
+      if (userEntityId == e.donorId) {
+        return e.recipientEstablishmentName;
+      }
+      if (userEntityId == e.recipientId) {
+        return e.donorEstablishmentName;
+      }
+      return "";
+    });
+  }
+}

--- a/lib/models/user_data.dart
+++ b/lib/models/user_data.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:zachranobed/models/entity_pair.dart';
 
 abstract class UserData extends ChangeNotifier {
   final String entityId;
@@ -7,6 +8,8 @@ abstract class UserData extends ChangeNotifier {
   final String establishmentId;
   final String organization;
   final int? lastAcceptedAppTermsVersion;
+  final EntityPair activePair;
+  final bool hasMultiplePairs;
 
   UserData({
     required this.entityId,
@@ -14,7 +17,9 @@ abstract class UserData extends ChangeNotifier {
     required this.establishmentName,
     required this.establishmentId,
     required this.organization,
-    required this.lastAcceptedAppTermsVersion
+    required this.lastAcceptedAppTermsVersion,
+    required this.activePair,
+    required this.hasMultiplePairs,
   });
 
   String get debugInfo {
@@ -24,7 +29,12 @@ abstract class UserData extends ChangeNotifier {
       Establishment: $establishmentName,
       ID: $establishmentId,
       Organization: $organization,
-      Last accepted app terms version: $lastAcceptedAppTermsVersion
+      Last accepted app terms version: $lastAcceptedAppTermsVersion,
+      Active pair: ${activePair.donorId} <-> ${activePair.recipientId},
+      Has multiple pairs: $hasMultiplePairs
     ''';
   }
+
+  /// Creates a copy of this [UserData] object with a replaced [activePair].
+  UserData copyWith({required EntityPair activePair});
 }

--- a/lib/notifiers/delivery_notifier.dart
+++ b/lib/notifiers/delivery_notifier.dart
@@ -34,7 +34,7 @@ class DeliveryNotifier extends ChangeNotifier {
   void observeDelivery(Canteen canteen) {
     _streamSubscription?.cancel();
     _streamSubscription = _repository
-        .observeCurrentDelivery(entityId: canteen.entityId)
+        .observeCurrentDelivery(user: canteen)
         .listen((delivery) async {
       _delivery = delivery;
       notifyListeners();

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -47,7 +47,17 @@ class AppRouter extends $AppRouter {
         ),
         MaterialRoute(page: DebugRoute.page),
         MaterialRoute(page: AppTermsRoute.page),
-        MaterialRoute(page: OfferFoodOverviewRoute.page),
-    MaterialRoute(page: OfferFoodDetailRoute.page),
+        MaterialRoute(
+          page: OfferFoodOverviewRoute.page,
+          guards: [AuthGuard()],
+        ),
+        MaterialRoute(
+          page: OfferFoodDetailRoute.page,
+          guards: [AuthGuard()],
+        ),
+        MaterialRoute(
+          page: ChangeActivePairRoute.page,
+          guards: [AuthGuard()],
+        ),
       ];
 }

--- a/lib/routes/app_router.gr.dart
+++ b/lib/routes/app_router.gr.dart
@@ -8,51 +8,53 @@
 // coverage:ignore-file
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'package:auto_route/auto_route.dart' as _i16;
-import 'package:flutter/material.dart' as _i17;
+import 'package:auto_route/auto_route.dart' as _i17;
+import 'package:flutter/material.dart' as _i18;
+import 'package:zachranobed/features/activepair/presentation/change_active_pair_screen.dart'
+    as _i3;
 import 'package:zachranobed/features/appTerms/presentation/app_terms_screen.dart'
     as _i1;
-import 'package:zachranobed/features/debug/debug_screen.dart' as _i5;
+import 'package:zachranobed/features/debug/debug_screen.dart' as _i6;
 import 'package:zachranobed/features/foodboxes/domain/model/box_movement.dart'
-    as _i18;
+    as _i19;
 import 'package:zachranobed/features/foodboxes/presentation/screen/box_movement_detail_screen.dart'
     as _i2;
 import 'package:zachranobed/features/login/presentation/screen/login_screen.dart'
-    as _i9;
-import 'package:zachranobed/features/menu/presentation/contacts_screen.dart'
-    as _i4;
-import 'package:zachranobed/features/menu/presentation/menu_screen.dart'
     as _i10;
+import 'package:zachranobed/features/menu/presentation/contacts_screen.dart'
+    as _i5;
+import 'package:zachranobed/features/menu/presentation/menu_screen.dart'
+    as _i11;
 import 'package:zachranobed/features/offeredfood/domain/model/food_info.dart'
-    as _i20;
+    as _i21;
 import 'package:zachranobed/features/offeredfood/domain/model/offered_food.dart'
-    as _i19;
+    as _i20;
 import 'package:zachranobed/features/offeredfood/presentation/screens/donated_food_detail_screen.dart'
-    as _i6;
-import 'package:zachranobed/ui/screens/change_password_screen.dart' as _i3;
-import 'package:zachranobed/ui/screens/forgot_password_screen.dart' as _i7;
-import 'package:zachranobed/ui/screens/home_screen.dart' as _i8;
-import 'package:zachranobed/ui/screens/offer_food_detail_screen.dart' as _i11;
-import 'package:zachranobed/ui/screens/offer_food_overview_screen.dart' as _i12;
-import 'package:zachranobed/ui/screens/offer_food_screen.dart' as _i13;
+    as _i7;
+import 'package:zachranobed/ui/screens/change_password_screen.dart' as _i4;
+import 'package:zachranobed/ui/screens/forgot_password_screen.dart' as _i8;
+import 'package:zachranobed/ui/screens/home_screen.dart' as _i9;
+import 'package:zachranobed/ui/screens/offer_food_detail_screen.dart' as _i12;
+import 'package:zachranobed/ui/screens/offer_food_overview_screen.dart' as _i13;
+import 'package:zachranobed/ui/screens/offer_food_screen.dart' as _i14;
 import 'package:zachranobed/ui/screens/order_shipping_of_boxes_screen.dart'
-    as _i14;
-import 'package:zachranobed/ui/screens/thank_you_screen.dart' as _i15;
+    as _i15;
+import 'package:zachranobed/ui/screens/thank_you_screen.dart' as _i16;
 
-abstract class $AppRouter extends _i16.RootStackRouter {
+abstract class $AppRouter extends _i17.RootStackRouter {
   $AppRouter({super.navigatorKey});
 
   @override
-  final Map<String, _i16.PageFactory> pagesMap = {
+  final Map<String, _i17.PageFactory> pagesMap = {
     AppTermsRoute.name: (routeData) {
-      return _i16.AutoRoutePage<dynamic>(
+      return _i17.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const _i1.AppTermsScreen(),
       );
     },
     BoxMovementDetailRoute.name: (routeData) {
       final args = routeData.argsAs<BoxMovementDetailRouteArgs>();
-      return _i16.AutoRoutePage<dynamic>(
+      return _i17.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: _i2.BoxMovementDetailScreen(
           key: args.key,
@@ -60,63 +62,69 @@ abstract class $AppRouter extends _i16.RootStackRouter {
         ),
       );
     },
-    ChangePasswordRoute.name: (routeData) {
-      return _i16.AutoRoutePage<dynamic>(
+    ChangeActivePairRoute.name: (routeData) {
+      return _i17.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const _i3.ChangePasswordScreen(),
+        child: const _i3.ChangeActivePairScreen(),
+      );
+    },
+    ChangePasswordRoute.name: (routeData) {
+      return _i17.AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const _i4.ChangePasswordScreen(),
       );
     },
     ContactsRoute.name: (routeData) {
-      return _i16.AutoRoutePage<dynamic>(
+      return _i17.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const _i4.ContactsScreen(),
+        child: const _i5.ContactsScreen(),
       );
     },
     DebugRoute.name: (routeData) {
-      return _i16.AutoRoutePage<dynamic>(
+      return _i17.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const _i5.DebugScreen(),
+        child: const _i6.DebugScreen(),
       );
     },
     DonatedFoodDetailRoute.name: (routeData) {
       final args = routeData.argsAs<DonatedFoodDetailRouteArgs>();
-      return _i16.AutoRoutePage<dynamic>(
+      return _i17.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: _i6.DonatedFoodDetailScreen(
+        child: _i7.DonatedFoodDetailScreen(
           key: args.key,
           offeredFood: args.offeredFood,
         ),
       );
     },
     ForgotPasswordRoute.name: (routeData) {
-      return _i16.AutoRoutePage<dynamic>(
+      return _i17.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const _i7.ForgotPasswordScreen(),
+        child: const _i8.ForgotPasswordScreen(),
       );
     },
     HomeRoute.name: (routeData) {
-      return _i16.AutoRoutePage<dynamic>(
+      return _i17.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const _i8.HomeScreen(),
+        child: const _i9.HomeScreen(),
       );
     },
     LoginRoute.name: (routeData) {
-      return _i16.AutoRoutePage<dynamic>(
+      return _i17.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const _i9.LoginScreen(),
+        child: const _i10.LoginScreen(),
       );
     },
     MenuRoute.name: (routeData) {
-      return _i16.AutoRoutePage<dynamic>(
+      return _i17.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const _i10.MenuScreen(),
+        child: const _i11.MenuScreen(),
       );
     },
     OfferFoodDetailRoute.name: (routeData) {
       final args = routeData.argsAs<OfferFoodDetailRouteArgs>();
-      return _i16.AutoRoutePage<dynamic>(
+      return _i17.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: _i11.OfferFoodDetailScreen(
+        child: _i12.OfferFoodDetailScreen(
           key: args.key,
           editedFoodInfo: args.editedFoodInfo,
           allFoodInfos: args.allFoodInfos,
@@ -125,31 +133,31 @@ abstract class $AppRouter extends _i16.RootStackRouter {
     },
     OfferFoodOverviewRoute.name: (routeData) {
       final args = routeData.argsAs<OfferFoodOverviewRouteArgs>();
-      return _i16.AutoRoutePage<dynamic>(
+      return _i17.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: _i12.OfferFoodOverviewScreen(
+        child: _i13.OfferFoodOverviewScreen(
           key: args.key,
           foodInfos: args.foodInfos,
         ),
       );
     },
     OfferFoodRoute.name: (routeData) {
-      return _i16.AutoRoutePage<dynamic>(
+      return _i17.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const _i13.OfferFoodScreen(),
+        child: const _i14.OfferFoodScreen(),
       );
     },
     OrderShippingOfBoxesRoute.name: (routeData) {
-      return _i16.AutoRoutePage<dynamic>(
+      return _i17.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: const _i14.OrderShippingOfBoxesScreen(),
+        child: const _i15.OrderShippingOfBoxesScreen(),
       );
     },
     ThankYouRoute.name: (routeData) {
       final args = routeData.argsAs<ThankYouRouteArgs>();
-      return _i16.AutoRoutePage<dynamic>(
+      return _i17.AutoRoutePage<dynamic>(
         routeData: routeData,
-        child: _i15.ThankYouScreen(
+        child: _i16.ThankYouScreen(
           key: args.key,
           isSuccess: args.isSuccess,
           message: args.message,
@@ -161,8 +169,8 @@ abstract class $AppRouter extends _i16.RootStackRouter {
 
 /// generated route for
 /// [_i1.AppTermsScreen]
-class AppTermsRoute extends _i16.PageRouteInfo<void> {
-  const AppTermsRoute({List<_i16.PageRouteInfo>? children})
+class AppTermsRoute extends _i17.PageRouteInfo<void> {
+  const AppTermsRoute({List<_i17.PageRouteInfo>? children})
       : super(
           AppTermsRoute.name,
           initialChildren: children,
@@ -170,17 +178,17 @@ class AppTermsRoute extends _i16.PageRouteInfo<void> {
 
   static const String name = 'AppTermsRoute';
 
-  static const _i16.PageInfo<void> page = _i16.PageInfo<void>(name);
+  static const _i17.PageInfo<void> page = _i17.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i2.BoxMovementDetailScreen]
 class BoxMovementDetailRoute
-    extends _i16.PageRouteInfo<BoxMovementDetailRouteArgs> {
+    extends _i17.PageRouteInfo<BoxMovementDetailRouteArgs> {
   BoxMovementDetailRoute({
-    _i17.Key? key,
-    required _i18.BoxMovement boxMovement,
-    List<_i16.PageRouteInfo>? children,
+    _i18.Key? key,
+    required _i19.BoxMovement boxMovement,
+    List<_i17.PageRouteInfo>? children,
   }) : super(
           BoxMovementDetailRoute.name,
           args: BoxMovementDetailRouteArgs(
@@ -192,8 +200,8 @@ class BoxMovementDetailRoute
 
   static const String name = 'BoxMovementDetailRoute';
 
-  static const _i16.PageInfo<BoxMovementDetailRouteArgs> page =
-      _i16.PageInfo<BoxMovementDetailRouteArgs>(name);
+  static const _i17.PageInfo<BoxMovementDetailRouteArgs> page =
+      _i17.PageInfo<BoxMovementDetailRouteArgs>(name);
 }
 
 class BoxMovementDetailRouteArgs {
@@ -202,9 +210,9 @@ class BoxMovementDetailRouteArgs {
     required this.boxMovement,
   });
 
-  final _i17.Key? key;
+  final _i18.Key? key;
 
-  final _i18.BoxMovement boxMovement;
+  final _i19.BoxMovement boxMovement;
 
   @override
   String toString() {
@@ -213,9 +221,23 @@ class BoxMovementDetailRouteArgs {
 }
 
 /// generated route for
-/// [_i3.ChangePasswordScreen]
-class ChangePasswordRoute extends _i16.PageRouteInfo<void> {
-  const ChangePasswordRoute({List<_i16.PageRouteInfo>? children})
+/// [_i3.ChangeActivePairScreen]
+class ChangeActivePairRoute extends _i17.PageRouteInfo<void> {
+  const ChangeActivePairRoute({List<_i17.PageRouteInfo>? children})
+      : super(
+          ChangeActivePairRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'ChangeActivePairRoute';
+
+  static const _i17.PageInfo<void> page = _i17.PageInfo<void>(name);
+}
+
+/// generated route for
+/// [_i4.ChangePasswordScreen]
+class ChangePasswordRoute extends _i17.PageRouteInfo<void> {
+  const ChangePasswordRoute({List<_i17.PageRouteInfo>? children})
       : super(
           ChangePasswordRoute.name,
           initialChildren: children,
@@ -223,13 +245,13 @@ class ChangePasswordRoute extends _i16.PageRouteInfo<void> {
 
   static const String name = 'ChangePasswordRoute';
 
-  static const _i16.PageInfo<void> page = _i16.PageInfo<void>(name);
+  static const _i17.PageInfo<void> page = _i17.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i4.ContactsScreen]
-class ContactsRoute extends _i16.PageRouteInfo<void> {
-  const ContactsRoute({List<_i16.PageRouteInfo>? children})
+/// [_i5.ContactsScreen]
+class ContactsRoute extends _i17.PageRouteInfo<void> {
+  const ContactsRoute({List<_i17.PageRouteInfo>? children})
       : super(
           ContactsRoute.name,
           initialChildren: children,
@@ -237,13 +259,13 @@ class ContactsRoute extends _i16.PageRouteInfo<void> {
 
   static const String name = 'ContactsRoute';
 
-  static const _i16.PageInfo<void> page = _i16.PageInfo<void>(name);
+  static const _i17.PageInfo<void> page = _i17.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i5.DebugScreen]
-class DebugRoute extends _i16.PageRouteInfo<void> {
-  const DebugRoute({List<_i16.PageRouteInfo>? children})
+/// [_i6.DebugScreen]
+class DebugRoute extends _i17.PageRouteInfo<void> {
+  const DebugRoute({List<_i17.PageRouteInfo>? children})
       : super(
           DebugRoute.name,
           initialChildren: children,
@@ -251,17 +273,17 @@ class DebugRoute extends _i16.PageRouteInfo<void> {
 
   static const String name = 'DebugRoute';
 
-  static const _i16.PageInfo<void> page = _i16.PageInfo<void>(name);
+  static const _i17.PageInfo<void> page = _i17.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i6.DonatedFoodDetailScreen]
+/// [_i7.DonatedFoodDetailScreen]
 class DonatedFoodDetailRoute
-    extends _i16.PageRouteInfo<DonatedFoodDetailRouteArgs> {
+    extends _i17.PageRouteInfo<DonatedFoodDetailRouteArgs> {
   DonatedFoodDetailRoute({
-    _i17.Key? key,
-    required _i19.OfferedFood offeredFood,
-    List<_i16.PageRouteInfo>? children,
+    _i18.Key? key,
+    required _i20.OfferedFood offeredFood,
+    List<_i17.PageRouteInfo>? children,
   }) : super(
           DonatedFoodDetailRoute.name,
           args: DonatedFoodDetailRouteArgs(
@@ -273,8 +295,8 @@ class DonatedFoodDetailRoute
 
   static const String name = 'DonatedFoodDetailRoute';
 
-  static const _i16.PageInfo<DonatedFoodDetailRouteArgs> page =
-      _i16.PageInfo<DonatedFoodDetailRouteArgs>(name);
+  static const _i17.PageInfo<DonatedFoodDetailRouteArgs> page =
+      _i17.PageInfo<DonatedFoodDetailRouteArgs>(name);
 }
 
 class DonatedFoodDetailRouteArgs {
@@ -283,9 +305,9 @@ class DonatedFoodDetailRouteArgs {
     required this.offeredFood,
   });
 
-  final _i17.Key? key;
+  final _i18.Key? key;
 
-  final _i19.OfferedFood offeredFood;
+  final _i20.OfferedFood offeredFood;
 
   @override
   String toString() {
@@ -294,9 +316,9 @@ class DonatedFoodDetailRouteArgs {
 }
 
 /// generated route for
-/// [_i7.ForgotPasswordScreen]
-class ForgotPasswordRoute extends _i16.PageRouteInfo<void> {
-  const ForgotPasswordRoute({List<_i16.PageRouteInfo>? children})
+/// [_i8.ForgotPasswordScreen]
+class ForgotPasswordRoute extends _i17.PageRouteInfo<void> {
+  const ForgotPasswordRoute({List<_i17.PageRouteInfo>? children})
       : super(
           ForgotPasswordRoute.name,
           initialChildren: children,
@@ -304,13 +326,13 @@ class ForgotPasswordRoute extends _i16.PageRouteInfo<void> {
 
   static const String name = 'ForgotPasswordRoute';
 
-  static const _i16.PageInfo<void> page = _i16.PageInfo<void>(name);
+  static const _i17.PageInfo<void> page = _i17.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i8.HomeScreen]
-class HomeRoute extends _i16.PageRouteInfo<void> {
-  const HomeRoute({List<_i16.PageRouteInfo>? children})
+/// [_i9.HomeScreen]
+class HomeRoute extends _i17.PageRouteInfo<void> {
+  const HomeRoute({List<_i17.PageRouteInfo>? children})
       : super(
           HomeRoute.name,
           initialChildren: children,
@@ -318,13 +340,13 @@ class HomeRoute extends _i16.PageRouteInfo<void> {
 
   static const String name = 'HomeRoute';
 
-  static const _i16.PageInfo<void> page = _i16.PageInfo<void>(name);
+  static const _i17.PageInfo<void> page = _i17.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i9.LoginScreen]
-class LoginRoute extends _i16.PageRouteInfo<void> {
-  const LoginRoute({List<_i16.PageRouteInfo>? children})
+/// [_i10.LoginScreen]
+class LoginRoute extends _i17.PageRouteInfo<void> {
+  const LoginRoute({List<_i17.PageRouteInfo>? children})
       : super(
           LoginRoute.name,
           initialChildren: children,
@@ -332,13 +354,13 @@ class LoginRoute extends _i16.PageRouteInfo<void> {
 
   static const String name = 'LoginRoute';
 
-  static const _i16.PageInfo<void> page = _i16.PageInfo<void>(name);
+  static const _i17.PageInfo<void> page = _i17.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i10.MenuScreen]
-class MenuRoute extends _i16.PageRouteInfo<void> {
-  const MenuRoute({List<_i16.PageRouteInfo>? children})
+/// [_i11.MenuScreen]
+class MenuRoute extends _i17.PageRouteInfo<void> {
+  const MenuRoute({List<_i17.PageRouteInfo>? children})
       : super(
           MenuRoute.name,
           initialChildren: children,
@@ -346,18 +368,18 @@ class MenuRoute extends _i16.PageRouteInfo<void> {
 
   static const String name = 'MenuRoute';
 
-  static const _i16.PageInfo<void> page = _i16.PageInfo<void>(name);
+  static const _i17.PageInfo<void> page = _i17.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i11.OfferFoodDetailScreen]
+/// [_i12.OfferFoodDetailScreen]
 class OfferFoodDetailRoute
-    extends _i16.PageRouteInfo<OfferFoodDetailRouteArgs> {
+    extends _i17.PageRouteInfo<OfferFoodDetailRouteArgs> {
   OfferFoodDetailRoute({
-    _i17.Key? key,
-    required _i20.FoodInfo editedFoodInfo,
-    required List<_i20.FoodInfo> allFoodInfos,
-    List<_i16.PageRouteInfo>? children,
+    _i18.Key? key,
+    required _i21.FoodInfo editedFoodInfo,
+    required List<_i21.FoodInfo> allFoodInfos,
+    List<_i17.PageRouteInfo>? children,
   }) : super(
           OfferFoodDetailRoute.name,
           args: OfferFoodDetailRouteArgs(
@@ -370,8 +392,8 @@ class OfferFoodDetailRoute
 
   static const String name = 'OfferFoodDetailRoute';
 
-  static const _i16.PageInfo<OfferFoodDetailRouteArgs> page =
-      _i16.PageInfo<OfferFoodDetailRouteArgs>(name);
+  static const _i17.PageInfo<OfferFoodDetailRouteArgs> page =
+      _i17.PageInfo<OfferFoodDetailRouteArgs>(name);
 }
 
 class OfferFoodDetailRouteArgs {
@@ -381,11 +403,11 @@ class OfferFoodDetailRouteArgs {
     required this.allFoodInfos,
   });
 
-  final _i17.Key? key;
+  final _i18.Key? key;
 
-  final _i20.FoodInfo editedFoodInfo;
+  final _i21.FoodInfo editedFoodInfo;
 
-  final List<_i20.FoodInfo> allFoodInfos;
+  final List<_i21.FoodInfo> allFoodInfos;
 
   @override
   String toString() {
@@ -394,13 +416,13 @@ class OfferFoodDetailRouteArgs {
 }
 
 /// generated route for
-/// [_i12.OfferFoodOverviewScreen]
+/// [_i13.OfferFoodOverviewScreen]
 class OfferFoodOverviewRoute
-    extends _i16.PageRouteInfo<OfferFoodOverviewRouteArgs> {
+    extends _i17.PageRouteInfo<OfferFoodOverviewRouteArgs> {
   OfferFoodOverviewRoute({
-    _i17.Key? key,
-    required List<_i20.FoodInfo> foodInfos,
-    List<_i16.PageRouteInfo>? children,
+    _i18.Key? key,
+    required List<_i21.FoodInfo> foodInfos,
+    List<_i17.PageRouteInfo>? children,
   }) : super(
           OfferFoodOverviewRoute.name,
           args: OfferFoodOverviewRouteArgs(
@@ -412,8 +434,8 @@ class OfferFoodOverviewRoute
 
   static const String name = 'OfferFoodOverviewRoute';
 
-  static const _i16.PageInfo<OfferFoodOverviewRouteArgs> page =
-      _i16.PageInfo<OfferFoodOverviewRouteArgs>(name);
+  static const _i17.PageInfo<OfferFoodOverviewRouteArgs> page =
+      _i17.PageInfo<OfferFoodOverviewRouteArgs>(name);
 }
 
 class OfferFoodOverviewRouteArgs {
@@ -422,9 +444,9 @@ class OfferFoodOverviewRouteArgs {
     required this.foodInfos,
   });
 
-  final _i17.Key? key;
+  final _i18.Key? key;
 
-  final List<_i20.FoodInfo> foodInfos;
+  final List<_i21.FoodInfo> foodInfos;
 
   @override
   String toString() {
@@ -433,9 +455,9 @@ class OfferFoodOverviewRouteArgs {
 }
 
 /// generated route for
-/// [_i13.OfferFoodScreen]
-class OfferFoodRoute extends _i16.PageRouteInfo<void> {
-  const OfferFoodRoute({List<_i16.PageRouteInfo>? children})
+/// [_i14.OfferFoodScreen]
+class OfferFoodRoute extends _i17.PageRouteInfo<void> {
+  const OfferFoodRoute({List<_i17.PageRouteInfo>? children})
       : super(
           OfferFoodRoute.name,
           initialChildren: children,
@@ -443,13 +465,13 @@ class OfferFoodRoute extends _i16.PageRouteInfo<void> {
 
   static const String name = 'OfferFoodRoute';
 
-  static const _i16.PageInfo<void> page = _i16.PageInfo<void>(name);
+  static const _i17.PageInfo<void> page = _i17.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i14.OrderShippingOfBoxesScreen]
-class OrderShippingOfBoxesRoute extends _i16.PageRouteInfo<void> {
-  const OrderShippingOfBoxesRoute({List<_i16.PageRouteInfo>? children})
+/// [_i15.OrderShippingOfBoxesScreen]
+class OrderShippingOfBoxesRoute extends _i17.PageRouteInfo<void> {
+  const OrderShippingOfBoxesRoute({List<_i17.PageRouteInfo>? children})
       : super(
           OrderShippingOfBoxesRoute.name,
           initialChildren: children,
@@ -457,17 +479,17 @@ class OrderShippingOfBoxesRoute extends _i16.PageRouteInfo<void> {
 
   static const String name = 'OrderShippingOfBoxesRoute';
 
-  static const _i16.PageInfo<void> page = _i16.PageInfo<void>(name);
+  static const _i17.PageInfo<void> page = _i17.PageInfo<void>(name);
 }
 
 /// generated route for
-/// [_i15.ThankYouScreen]
-class ThankYouRoute extends _i16.PageRouteInfo<ThankYouRouteArgs> {
+/// [_i16.ThankYouScreen]
+class ThankYouRoute extends _i17.PageRouteInfo<ThankYouRouteArgs> {
   ThankYouRoute({
-    _i17.Key? key,
+    _i18.Key? key,
     required bool isSuccess,
     required String message,
-    List<_i16.PageRouteInfo>? children,
+    List<_i17.PageRouteInfo>? children,
   }) : super(
           ThankYouRoute.name,
           args: ThankYouRouteArgs(
@@ -480,8 +502,8 @@ class ThankYouRoute extends _i16.PageRouteInfo<ThankYouRouteArgs> {
 
   static const String name = 'ThankYouRoute';
 
-  static const _i16.PageInfo<ThankYouRouteArgs> page =
-      _i16.PageInfo<ThankYouRouteArgs>(name);
+  static const _i17.PageInfo<ThankYouRouteArgs> page =
+      _i17.PageInfo<ThankYouRouteArgs>(name);
 }
 
 class ThankYouRouteArgs {
@@ -491,7 +513,7 @@ class ThankYouRouteArgs {
     required this.message,
   });
 
-  final _i17.Key? key;
+  final _i18.Key? key;
 
   final bool isSuccess;
 

--- a/lib/services/delivery_service.dart
+++ b/lib/services/delivery_service.dart
@@ -33,10 +33,8 @@ class DeliveryService {
   ///
   /// This method sets up a Firestore stream to listen for changes in the
   /// `deliveries` collection. It filters deliveries based on the provided
-  /// [donorId], type and last midnight timestamp to get "today's" delivery.
-  ///
-  /// The [donorId] parameter is the ID of the donor whose delivery is to be
-  /// observed.
+  /// [donorId] & [recipientId] pair, type and last midnight timestamp to get
+  /// "today's" delivery.
   ///
   /// The method returns a `Stream` of `DeliveryDto?`. Each `DeliveryDto?` in
   /// the `Stream` represents a delivery for the donor. The `Stream` emits a new
@@ -48,11 +46,15 @@ class DeliveryService {
   /// collection.
   /// The `map` method is used to transform the snapshots into  `DeliveryDto?`
   /// objects.
-  Stream<DeliveryDto?> observeDelivery(String donorId) {
+  Stream<DeliveryDto?> observeDelivery({
+    required String donorId,
+    required String recipientId,
+  }) {
     final now = DateTime.now();
     final lastMidnight = DateTime(now.year, now.month, now.day);
     final snapshots = _collection
         .where('donorId', isEqualTo: donorId)
+        .where('recipientId', isEqualTo: recipientId)
         .where('type', isEqualTo: DeliveryTypeDto.foodDelivery.toJson())
         .whereTime('deliveryDate', lastMidnight)
         .snapshots();

--- a/lib/services/di/services_dependency_container.dart
+++ b/lib/services/di/services_dependency_container.dart
@@ -1,4 +1,5 @@
 import 'package:get_it/get_it.dart';
+import 'package:zachranobed/common/prefs/app_preferences.dart';
 import 'package:zachranobed/routes/app_router.dart';
 import 'package:zachranobed/services/auth_service.dart';
 import 'package:zachranobed/services/carrier_service.dart';
@@ -22,6 +23,7 @@ class ServicesDependencyContainer {
       AuthService(
         GetIt.I<EntityService>(),
         GetIt.I<EntityPairService>(),
+        GetIt.I<AppPreferences>(),
       ),
     );
     GetIt.I.registerSingleton(ConfigurationService());

--- a/lib/ui/screens/order_shipping_of_boxes_screen.dart
+++ b/lib/ui/screens/order_shipping_of_boxes_screen.dart
@@ -174,7 +174,7 @@ class _OrderShippingOfBoxesScreenState
     }
 
     final available = await _foodBoxRepository.verifyAvailableBoxCount(
-      entityId: user.entityId,
+      user: user,
       requiredBoxes: requiredBoxes,
       getQuantity: (e) => e.quantityAtCharity,
     );
@@ -194,13 +194,8 @@ class _OrderShippingOfBoxesScreenState
       return false;
     }
 
-    final donorId = user.donorIds.first;
-    final carrierId = user.carrierIds.first;
-
     return _foodBoxRepository.createBoxDelivery(
-      entityId: user.entityId,
-      donorId: donorId,
-      carrierId: carrierId,
+      user: user,
       boxInfo: _shippingOfBoxesSections,
     );
   }

--- a/lib/ui/screens/overview_screen.dart
+++ b/lib/ui/screens/overview_screen.dart
@@ -8,7 +8,10 @@ import 'package:zachranobed/features/foodboxes/presentation/widget/box_data_tabl
 import 'package:zachranobed/features/offeredfood/presentation/widget/card_list.dart';
 import 'package:zachranobed/features/offeredfood/presentation/widget/donated_food_list.dart';
 import 'package:zachranobed/models/canteen.dart';
+import 'package:zachranobed/models/charity.dart';
 import 'package:zachranobed/routes/app_router.gr.dart';
+import 'package:zachranobed/ui/widgets/button.dart';
+import 'package:zachranobed/ui/widgets/card_row.dart';
 import 'package:zachranobed/ui/widgets/new_offer_floating_button.dart';
 import 'package:zachranobed/ui/widgets/new_shipping_of_boxes_floating_button.dart';
 
@@ -19,7 +22,7 @@ class OverviewScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final user = HelperService.getCurrentUser(context);
+    final user = HelperService.watchCurrentUser(context);
 
     return Scaffold(
       appBar: AppBar(
@@ -48,6 +51,7 @@ class OverviewScreen extends StatelessWidget {
             ),
             sliver: MultiSliver(
               children: [
+                _buildActiveCanteen(context),
                 CardList(user: user),
                 const SizedBox(height: GapSize.m),
                 BoxDataTable(user: user),
@@ -67,6 +71,36 @@ class OverviewScreen extends StatelessWidget {
       title: context.l10n!.lastDonated,
       itemsLimit: 5,
       alwaysShowTitle: false,
+    );
+  }
+
+  Widget _buildActiveCanteen(BuildContext context) {
+    final user = HelperService.watchCurrentUser(context);
+    if (user is! Charity) {
+      return const SizedBox();
+    }
+    return Column(
+      children: [
+        CardRow(
+          label: context.l10n!.activePairCardCanteenLabel,
+          title: user.activePair.donorEstablishmentName,
+          action: (context) {
+            if (!user.hasMultiplePairs) {
+              return const SizedBox();
+            }
+            return ZOButton(
+              text: context.l10n!.activePairCardChangeAction,
+              type: ZOButtonType.secondary,
+              height: 40.0,
+              fullWidth: false,
+              onPressed: () {
+                context.router.push(const ChangeActivePairRoute());
+              },
+            );
+          },
+        ),
+        const SizedBox(height: GapSize.xs),
+      ],
     );
   }
 }

--- a/lib/ui/widgets/button.dart
+++ b/lib/ui/widgets/button.dart
@@ -27,6 +27,7 @@ class ZOButton extends StatelessWidget {
       minimumSize: fullWidth ? Size.fromHeight(height) : null,
       shape: const StadiumBorder(),
       textStyle: const TextStyle(fontSize: FontSize.xs),
+      elevation: 0.0,
     );
 
     if (icon != null) {

--- a/lib/ui/widgets/card_row.dart
+++ b/lib/ui/widgets/card_row.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:zachranobed/common/constants.dart';
+
+/// A widget that displays a row of information within a card-like container.
+class CardRow extends StatelessWidget {
+  /// An optional label displayed above the title.
+  final String? label;
+
+  /// The title of the row.
+  final String title;
+
+  /// An optional subtitle displayed below the title.
+  final WidgetBuilder? subtitle;
+
+  /// An optional action widget displayed at the end of the row.
+  final WidgetBuilder? action;
+
+  /// Creates a [CardRow] widget.
+  const CardRow({
+    super.key,
+    this.label,
+    required this.title,
+    this.subtitle,
+    this.action,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: ZOColors.cardBackground,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: WidgetStyle.padding,
+          vertical: WidgetStyle.paddingSmall,
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: _rowContent(context),
+            ),
+            if (action != null) Builder(builder: action!),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Builds the content of the row, including the label, title, and subtitle.
+  Widget _rowContent(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (label != null)
+          Column(
+            children: [
+              Text(
+                label!,
+                style: textTheme.labelMedium?.copyWith(
+                  color: ZOColors.onPrimaryLight,
+                ),
+              ),
+              const SizedBox(height: 4),
+            ],
+          ),
+        Text(
+          title,
+          style: textTheme.titleMedium,
+        ),
+        if (subtitle != null)
+          Column(
+            children: [
+              const SizedBox(height: 4),
+              Builder(builder: subtitle!),
+            ],
+          ),
+      ],
+    );
+  }
+}

--- a/lib/ui/widgets/contact_row.dart
+++ b/lib/ui/widgets/contact_row.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:zachranobed/common/constants.dart';
 import 'package:zachranobed/extensions/build_context_extensions.dart';
+import 'package:zachranobed/ui/widgets/card_row.dart';
 
 /// A widget that displays contact information, including name, optional phone
 /// number, and whether the contact is a preferred contact. If contact can be
@@ -31,70 +32,15 @@ class ContactRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: double.infinity,
-      decoration: BoxDecoration(
-        color: ZOColors.cardBackground,
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(
-          horizontal: WidgetStyle.padding,
-          vertical: WidgetStyle.paddingSmall,
-        ),
-        child: Row(
-          children: [
-            Expanded(
-              child: _rowContent(context),
-            ),
-            _actionContent(),
-          ],
-        ),
-      ),
+    return CardRow(
+      label: isPreferred ? context.l10n!.contactsPreferredLabel : null,
+      title: name,
+      subtitle: _subtitleContent,
+      action: _actionContent,
     );
   }
 
-  Widget _rowContent(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        if (isPreferred)
-          Column(
-            children: [
-              Text(
-                context.l10n!.contactsPreferredLabel,
-                style: textTheme.labelMedium?.copyWith(
-                  color: ZOColors.onPrimaryLight,
-                ),
-              ),
-              const SizedBox(height: 4),
-            ],
-          ),
-        Text(
-          name,
-          style: textTheme.titleMedium,
-        ),
-        const SizedBox(height: 4),
-        if (phoneNumber != null)
-          Text(
-            phoneNumber ?? "",
-            style: textTheme.bodyMedium?.copyWith(
-              color: ZOColors.onPrimaryLight,
-            ),
-          )
-        else
-          Text(
-            context.l10n!.contactsNoPhoneLabel,
-            style: textTheme.bodyMedium?.copyWith(
-              color: ZOColors.outline,
-            ),
-          ),
-      ],
-    );
-  }
-
-  Widget _actionContent() {
+  Widget _actionContent(BuildContext context) {
     return FutureBuilder(
       future: _canCall,
       builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
@@ -110,6 +56,25 @@ class ContactRow extends StatelessWidget {
         return const SizedBox();
       },
     );
+  }
+
+  Widget _subtitleContent(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    if (phoneNumber != null) {
+      return Text(
+        phoneNumber ?? "",
+        style: textTheme.bodyMedium?.copyWith(
+          color: ZOColors.onPrimaryLight,
+        ),
+      );
+    } else {
+      return Text(
+        context.l10n!.contactsNoPhoneLabel,
+        style: textTheme.bodyMedium?.copyWith(
+          color: ZOColors.outline,
+        ),
+      );
+    }
   }
 
   void _dialUpNumber() async {

--- a/lib/ui/widgets/menu/menu_section.dart
+++ b/lib/ui/widgets/menu/menu_section.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:zachranobed/common/constants.dart';
 
 class MenuSection extends StatelessWidget {
-  final String label;
+  final WidgetBuilder label;
   final List<Widget> menuItems;
 
   const MenuSection({
@@ -11,22 +11,32 @@ class MenuSection extends StatelessWidget {
     required this.menuItems,
   });
 
+  MenuSection.simple({
+    Key? key,
+    required String label,
+    required List<Widget> menuItems,
+  }) : this(
+          key: key,
+          label: (context) => _label(context, label),
+          menuItems: menuItems,
+        );
+
   @override
   Widget build(BuildContext context) {
     return Column(
       children: [
-        Row(
-          children: [
-            Text(
-              label,
-              style: Theme.of(context).textTheme.titleMedium,
-            )
-          ],
-        ),
+        Row(children: [Builder(builder: label)]),
         const SizedBox(height: 8),
         for (var item in menuItems) item,
         const SizedBox(height: GapSize.m),
       ],
+    );
+  }
+
+  static Widget _label(BuildContext context, String label) {
+    return Text(
+      label,
+      style: Theme.of(context).textTheme.titleMedium,
     );
   }
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -13,6 +13,7 @@ import firebase_crashlytics
 import firebase_messaging
 import flutter_local_notifications
 import package_info_plus
+import shared_preferences_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -24,5 +25,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -609,18 +609,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -665,18 +665,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -733,6 +733,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   petitparser:
     dependency: transitive
     description:
@@ -741,6 +765,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.2"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -781,6 +813,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: d3bbe5553a986e83980916ded2f0b435ef2e1893dfaa29d5a7a790d0eca12180
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "480ba4345773f56acda9abf5f50bd966f581dac5d514e5fc4a18c62976bbba7e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: c4b35f6cb8f63c147312c054ce7c2254c8066745125264f0c88739c417fc9d9f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.2"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: "7b15ffb9387ea3e237bb7a66b8a23d2147663d391cafc5c8f37b2e7b4bde5d21"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.2"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:
@@ -878,10 +966,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.0"
   timezone:
     dependency: transitive
     description:
@@ -1014,10 +1102,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.2.1"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,7 @@ dependencies:
   collection: ^1.18.0
   device_info_plus: ^9.1.2
   android_id: ^0.3.6
+  shared_preferences: ^2.2.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# Description

* Sorry for the big PR 😿 
* Jira: https://etnetera.atlassian.net/browse/ZOB-189
* Figma: https://www.figma.com/design/j8ffUUxMVaRKjwunypj8GY/zj---Flutter-App?node-id=5430-17855
* See testing notes in https://etnetera.atlassian.net/browse/ZOB-189?focusedCommentId=1409960

# Implementation Notes

* I have created a new feature folder (**"activepair"**), which handles loading data for the screen and changing the active pair. The implementation is generic to allow for future extension to Canteen users (currently, only Charity can have multiple Canteens).
* The selected pair is stored in `SharedPreferences`. I’ve created a wrapper (`AppPreferences`) to centralize key management in one place.
* I set the elevation of the `ZOButton` to zero to match the Figma design.
* Several changes were made in the Services to work correctly with selected active-pair. 


# Example
👇  No changes for canteen user
<img width=300 src="https://github.com/user-attachments/assets/21289dd0-3433-4278-bc2b-fc294ad7a8ad">

👇 Charity user with only one canteen has banner, but without "Change" action
<img width=300 src="https://github.com/user-attachments/assets/99b4d2e1-20f4-442a-ab6e-9d74a5c62d24">

👇 Charity user with multiple canteens has banner with a "Change" action
<img width=300 src="https://github.com/user-attachments/assets/28d02af9-7275-4892-b272-c37cb23a2ae6">

👇 Charity user with multiple canteens can switch between them
<img width=300 src="https://github.com/user-attachments/assets/520a9c16-b27c-436a-9953-c7bf80b71fb1">

👇 After switching to a new canteen use is redirected to dashboard and every screen is refreshed to reflect data of a selected canteen
<img width=300 src="https://github.com/user-attachments/assets/3f7efe09-0541-41fb-92e6-0533528a4d90">

👇 In contacts screen we would like to also mark a selected canteen
<img width=300 src="https://github.com/user-attachments/assets/207cd69f-c7f9-4e3e-9bb4-834c7494a34b">


