### PR TITLE
ZOB-219 Offset initial time for "consume-by" field

### DIFF
--- a/lib/common/constants.dart
+++ b/lib/common/constants.dart
@@ -42,6 +42,9 @@ class ZOStrings {
 class Constants {
   static const lastWeekOfYear = 52;
 
+  /// The offset in minutes for "consume-by" field.
+  static const foodConsumeByMinutesOffset = 30;
+
   // ZOB-234 Use shorter confirmation time for personal delivery
   static const pickupConfirmationTimeDefault = 45;
   static const pickupConfirmationTimePersonal = 20;

--- a/lib/ui/widgets/food_date_time_chips.dart
+++ b/lib/ui/widgets/food_date_time_chips.dart
@@ -38,6 +38,9 @@ class FoodDateTimeChips extends StatelessWidget {
   /// is selected.
   final bool hasTime;
 
+  /// Lambda function to provide initial time for the time picker.
+  final DateTime? Function()? initialTime;
+
   /// Creates a [FoodDateTimeChips] widget.
   const FoodDateTimeChips({
     super.key,
@@ -46,6 +49,7 @@ class FoodDateTimeChips extends StatelessWidget {
     required this.options,
     required this.formatSelectedDate,
     this.hasTime = true,
+    this.initialTime,
     this.focusNode,
     this.onValidation,
   });
@@ -109,7 +113,8 @@ class FoodDateTimeChips extends StatelessWidget {
     switch (option.date) {
       case FoodDateTimeSpecified(date: final date):
         if (hasTime) {
-          final initial = state.value?.getDate() ?? DateTime.now();
+          final initial =
+              state.value?.getDate() ?? initialTime?.call() ?? DateTime.now();
           time = await DateTimePicker.pickTime(
             context: context,
             initial: TimeOfDay(

--- a/lib/ui/widgets/food_section_fields.dart
+++ b/lib/ui/widgets/food_section_fields.dart
@@ -1,4 +1,3 @@
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:zachranobed/common/constants.dart';
@@ -213,7 +212,8 @@ class _FoodSectionFieldsState extends State<FoodSectionFields> {
           final now = DateTime.now();
           final date = await DateTimePicker.pickDateTime(
             context: context,
-            initial: widget.foodSections[index].consumeBy?.getDate() ?? now,
+            initial: widget.foodSections[index].consumeBy?.getDate() ??
+                _consumeByInitialTime(),
             minimum: now,
           );
 
@@ -240,6 +240,7 @@ class _FoodSectionFieldsState extends State<FoodSectionFields> {
           FieldValidationUtils.getConsumeByValidator(context),
         ),
         formatSelectedDate: context.l10n!.consumeByTemplate,
+        initialTime: _consumeByInitialTime,
       ),
     ];
   }
@@ -348,5 +349,10 @@ class _FoodSectionFieldsState extends State<FoodSectionFields> {
 
   Widget _buildGap() {
     return const SizedBox(height: GapSize.xl);
+  }
+
+  DateTime _consumeByInitialTime() {
+    const offset = Duration(minutes: Constants.foodConsumeByMinutesOffset);
+    return DateTime.now().add(offset);
   }
 }


### PR DESCRIPTION
# Description

* This PR offsets initial time for "consume-by" field by 30 minutes, so that "default" time is valid (in the future).