### PR TITLE
ZOB-174 Update date picker to only show calendar view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is a changelog for **ZachranObed** application.
 ### Fixed
 
 ### Changed
+- **ZOB-174** Update date picker to only show calendar view.
 - **ZOB-292** Update form layout.
 
 ### Removed

--- a/lib/ui/widgets/date_time_picker.dart
+++ b/lib/ui/widgets/date_time_picker.dart
@@ -49,6 +49,7 @@ class DateTimePicker {
     return showDatePicker(
       context: context,
       initialDate: initial,
+      initialEntryMode: DatePickerEntryMode.calendarOnly,
       firstDate: minimum ?? DateTime(DateTime.now().year),
       lastDate: DateTime(2100),
     );


### PR DESCRIPTION
# Description

* JIRA: https://go.jira.etnetera.cz/browse/ZOB-174
* We have agreed to leave only-calendar option for DatePicker.