### PR TITLE
Fixed iOS build warning with deprecated SDK used for build

### DIFF
--- a/.github/actions/build-ipa/action.yml
+++ b/.github/actions/build-ipa/action.yml
@@ -54,6 +54,7 @@ runs:
         cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
 
     - name: Select Xcode version
+      shell: bash
       run: sudo xcode-select -s /Applications/Xcode_16.2.app
 
     # Builds a release IPA for the given flavor.

--- a/.github/actions/build-ipa/action.yml
+++ b/.github/actions/build-ipa/action.yml
@@ -53,6 +53,9 @@ runs:
         mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
         cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
 
+    - name: Select Xcode version
+      run: sudo xcode-select -s /Applications/Xcode_16.2.app
+
     # Builds a release IPA for the given flavor.
     - name: Build iOS IPA
       shell: bash


### PR DESCRIPTION
Added step into build-ipa action that selects Xcode 16.2 as build tool. It mitigates the warning of old SDK used for building the app.